### PR TITLE
Fixed header style in right sidebar for light mode

### DIFF
--- a/.changeset/warm-eggs-decide.md
+++ b/.changeset/warm-eggs-decide.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-theme-redoc': patch
+---
+
+Fixed header style in right sidebar for light mode

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
@@ -60,7 +60,9 @@ html[data-theme='dark'] .redocusaurus h2 > a:nth-child(1)::before {
 /** Fixes https://github.com/rohit-gohri/redocusaurus/issues/65 */
 html:not([data-theme='dark'])
   .redocusaurus
-  div[id^='operation']
+  .redoc-wrap
+  .api-content
+  > div
   > div:nth-child(1)
   > div:nth-child(2)
   h3 {


### PR DESCRIPTION
Fixes https://github.com/rohit-gohri/redocusaurus/issues/65 with the addition of not needing an operationId.