### PR TITLE
Add new option addRoute to add the route for the generated docs

### DIFF
--- a/.changeset/tricky-toes-fly.md
+++ b/.changeset/tricky-toes-fly.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-plugin-redoc': minor
+---
+
+Add addRoute option to create a route for the generated docs, default to true

--- a/packages/docusaurus-plugin-redoc/src/index.ts
+++ b/packages/docusaurus-plugin-redoc/src/index.ts
@@ -75,23 +75,25 @@ export default function redocPlugin(
         JSON.stringify(options.layout),
       );
 
-      const routePath = options.routePath.startsWith('/')
-        ? options.routePath.slice(1)
-        : options.routePath;
-      const routeOptions = {
-        path: normalizeUrl([baseUrl, routePath]),
-        component: options.apiDocComponent,
-        modules: {
-          spec: specData,
-          layoutProps: layoutData,
-        },
-        exact: true,
-      };
+      if (options.addRoute) {
+        const routePath = options.routePath.startsWith('/')
+          ? options.routePath.slice(1)
+          : options.routePath;
+        const routeOptions = {
+          path: normalizeUrl([baseUrl, routePath]),
+          component: options.apiDocComponent,
+          modules: {
+            spec: specData,
+            layoutProps: layoutData,
+          },
+          exact: true,
+        };
 
-      if (debug) {
-        console.error('[REDOCUSAURUS_PLUGIN] Route:', routeOptions);
+        if (debug) {
+          console.error('[REDOCUSAURUS_PLUGIN] Route:', routeOptions);
+        }
+        addRoute(routeOptions);
       }
-      addRoute(routeOptions);
     },
   };
 }

--- a/packages/docusaurus-plugin-redoc/src/options.ts
+++ b/packages/docusaurus-plugin-redoc/src/options.ts
@@ -33,12 +33,14 @@ export interface PluginOptions {
   specUrl?: string;
   layout?: LayoutProps;
   debug?: boolean;
+  addRoute?: boolean;
   routePath?: string;
   apiDocComponent?: string;
 }
 
 export interface PluginOptionsWithDefault extends PluginOptions {
   debug: boolean;
+  addRoute: boolean;
   routePath: string;
   apiDocComponent: string;
 }
@@ -46,6 +48,7 @@ export interface PluginOptionsWithDefault extends PluginOptions {
 export const DEFAULT_OPTIONS: PluginOptionsWithDefault = {
   layout: {},
   debug: false,
+  addRoute: true,
   routePath: '/api/', // URL Route.
   apiDocComponent: '@theme/ApiDoc',
 };
@@ -56,6 +59,7 @@ export const PluginOptionSchema = Joi.object({
   specUrl: Joi.string().uri({ allowRelative: true }),
   layout: Joi.any().default(DEFAULT_OPTIONS.layout),
   debug: Joi.boolean().default(DEFAULT_OPTIONS.debug),
+  addRoute: Joi.boolean().default(DEFAULT_OPTIONS.addRoute),
   routePath: Joi.string().default(DEFAULT_OPTIONS.routePath),
   apiDocComponent: Joi.string().default(DEFAULT_OPTIONS.apiDocComponent),
 });

--- a/website/docs/getting-started/Installation.md
+++ b/website/docs/getting-started/Installation.md
@@ -61,4 +61,41 @@ npm i --save redocusaurus
      };
      ```
 
-The API Doc will be available by default at `/api/` path. To customize it see [full plugin options](#options).
+The API Doc will be available by default at `/api/` path. If you wish to
+override this path, you may set the `routePath` option. To skip adding a
+route altogether, set the `addRoute` option to false. You will still be
+able to reference schema elements manually using [Schema Imports](/docs/guides/schema-imports).
+
+```js
+// docusaurus.config.js
+
+module.exports = {
+  // ...
+  presets: [
+    [
+      'redocusaurus',
+      {
+        specs: [
+          {
+            id: 'default-route',
+            // routePath: '/api/',
+            // addRoute: true,
+          },
+          {
+            id: 'route-overridden',
+            routePath: '/different-path/',
+            // addRoute: true,
+          },
+          {
+            id: 'no-route',
+            addRoute: false,
+          },
+        ],
+      },
+    ],
+  ],
+  // ...
+};
+```
+
+To customize it see [full plugin options](#options).


### PR DESCRIPTION
This will allow skipping the additional route for use cases where we only want to reference the react component in docs manually rather than displaying the entire generated documentation.