### PR TITLE
feat(theme): allow override redoc theme inside docusaurus.config file

### DIFF
--- a/.changeset/tiny-humans-wash.md
+++ b/.changeset/tiny-humans-wash.md
@@ -1,0 +1,6 @@
+---
+"redocusaurus-website": patch
+"docusaurus-theme-redoc": minor
+---
+
+feat(theme): allow override redoc theme inside docusaurus.config file

--- a/packages/docusaurus-theme-redoc/Readme.md
+++ b/packages/docusaurus-theme-redoc/Readme.md
@@ -48,14 +48,40 @@ See [here for full example.](https://github.com/rohit-gohri/redocusaurus/tree/ma
 
 ## Options
 
+```json
+/**
+   * Highlight color for docs
+   */
+primaryColor: '#1890ff',
+/**
+   * Options to pass to redoc
+   * @see https://github.com/redocly/redoc#redoc-options-object
+   */
+redocOptions: { hideDownloadButton: false, disableSearch: true },
+/**
+   * Options to pass to override RedocThemeObject
+   * @see https://github.com/Redocly/redoc#redoc-theme-object
+   */
+redocTheme: { typography: { fontSize: '16px' }},
+```
+
 ### primaryColor
 
-Hex code to be passed as the `main` color to [RedocStandalone](https://github.com/redocly/redoc#usage-as-a-react-component)
+Convenient way to provide the highlighted color used by Redoc.  
+This value will be used as `colors.primary.main` in the `redocTheme` option. Must be an hex value.
+
+### redocTheme
+
+Override the redoc theme object passed inside the `redocOptions`.  
+See the default [here](https://github.com/Redocly/redoc#redoc-theme-object).  
+Note: You should not provide any color using this property, as it will be the same value for dark and light themes.
 
 ### redocOptions
 
-Override the default redoc options passed to the [RedocStandalone](https://github.com/redocly/redoc#usage-as-a-react-component) component.
-See the defaults [here](https://github.com/rohit-gohri/redocusaurus/blob/main/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx#L101-L108).
+Override redoc options passed to [RedocStandalone](https://redoc.ly/docs/redoc/quickstart/react/) component.  
+See the defaults [here](https://github.com/rohit-gohri/redocusaurus/blob/main/packages/docusaurus-theme-redoc/src/redocData.ts#L6-L11).  
+Available properties [here](https://github.com/Redocly/redoc#redoc-options-object).  
+You cannot set theme property using this property, use `redocTheme` instead.
 
 ## Related Preset
 

--- a/packages/docusaurus-theme-redoc/src/index.ts
+++ b/packages/docusaurus-theme-redoc/src/index.ts
@@ -36,6 +36,7 @@ export default function redocTheme(
       const { setGlobalData } = actions;
       const globalData = getGlobalData(
         options.primaryColor,
+        options.redocTheme,
         options.redocOptions,
       );
 

--- a/packages/docusaurus-theme-redoc/src/redocData.ts
+++ b/packages/docusaurus-theme-redoc/src/redocData.ts
@@ -11,13 +11,22 @@ const defaultOptions: Partial<RedocRawOptions> = {
   suppressWarnings: true,
 };
 
-const getDefaultTheme = (primaryColor?: string): RedocThemeOverrides => ({
-  colors: {
-    primary: {
-      main: primaryColor || '#25c2a0',
+const getDefaultTheme = (
+  primaryColor?: string,
+  customTheme?: RedocThemeOverrides,
+): RedocThemeOverrides => {
+  return merge(
+    {},
+    {
+      colors: {
+        primary: {
+          main: primaryColor || '#25c2a0',
+        },
+      },
     },
-  },
-});
+    customTheme,
+  );
+};
 
 /**
  * TODO: Update colors from infima
@@ -33,10 +42,9 @@ const DOCUSAURUS = {
 };
 
 /**
- * NOTE: Variables taken from infima
- * @see https://github.com/facebookincubator/infima/blob/master/packages/core/styles/common/variables.pcss
+ * Theme override that is independant of Light/Black themes
  */
-const LIGHT_THEME_OPTIONS: RedocThemeOverrides = {
+const COMMON_THEME: RedocThemeOverrides = {
   typography: {
     fontFamily: 'var(--ifm-font-family-base)',
     fontSize: 'var(--ifm-font-size-base)',
@@ -60,6 +68,15 @@ const LIGHT_THEME_OPTIONS: RedocThemeOverrides = {
      * @see https://davidgoss.co/blog/api-documentation-redoc-docusaurus/
      */
     width: '300px',
+  },
+};
+
+/**
+ * NOTE: Variables taken from infima
+ * @see https://github.com/facebookincubator/infima/blob/master/packages/core/styles/common/variables.pcss
+ */
+const LIGHT_THEME_OPTIONS: RedocThemeOverrides = {
+  sidebar: {
     backgroundColor: '#ffffff',
   },
   rightPanel: {
@@ -97,32 +114,33 @@ const DARK_THEME_OPTIONS: RedocThemeOverrides = {
 };
 
 function getThemeOptions(
-  baseTheme: RedocThemeOverrides,
+  customTheme: RedocThemeOverrides,
   isDarkMode = false,
 ): RedocThemeOverrides {
-  const mergedTheme = merge({}, baseTheme, LIGHT_THEME_OPTIONS);
-
-  if (!isDarkMode) return mergedTheme;
-
-  return merge(mergedTheme, DARK_THEME_OPTIONS);
+  if (isDarkMode) {
+    return merge({}, COMMON_THEME, DARK_THEME_OPTIONS, customTheme);
+  } else {
+    return merge({}, COMMON_THEME, LIGHT_THEME_OPTIONS, customTheme);
+  }
 }
 
-export function getRedocThemes(baseTheme: RedocThemeOverrides): {
+export function getRedocThemes(customTheme: RedocThemeOverrides): {
   darkTheme: RedocThemeOverrides;
   lightTheme: RedocThemeOverrides;
 } {
   return {
-    lightTheme: getThemeOptions(baseTheme, false),
-    darkTheme: getThemeOptions(baseTheme, true),
+    lightTheme: getThemeOptions(customTheme, false),
+    darkTheme: getThemeOptions(customTheme, true),
   };
 }
 
 export function getGlobalData(
   primaryColor?: string,
+  customTheme?: RedocThemeOverrides,
   redocOptions?: Partial<RedocRawOptions>,
 ): GlobalData {
   const { lightTheme, darkTheme } = getRedocThemes(
-    getDefaultTheme(primaryColor),
+    getDefaultTheme(primaryColor, customTheme),
   );
 
   return {

--- a/packages/docusaurus-theme-redoc/src/theme/ServerStyle/index.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/ServerStyle/index.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 // @ts-ignore
-import {Context as DocusaurusContext} from '@docusaurus/docusaurusContext';
+import { Context as DocusaurusContext } from '@docusaurus/docusaurusContext';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { renderToString } from 'react-dom/server';

--- a/packages/docusaurus-theme-redoc/src/types/common.ts
+++ b/packages/docusaurus-theme-redoc/src/types/common.ts
@@ -47,6 +47,7 @@ export type RedocThemeOverrides = RecursivePartial<
 
 export interface ThemeOptions {
   primaryColor?: string;
+  redocTheme?: Partial<RedocRawOptions['theme']>;
   redocOptions?: Partial<Omit<RedocRawOptions, 'theme'>>;
 }
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -36,6 +36,11 @@ const redocusaurus = [
        * @see https://github.com/redocly/redoc#redoc-options-object
        */
       redocOptions: { hideDownloadButton: false, disableSearch: true },
+      /**
+       * Options to pass to override RedocThemeObject
+       * @see https://github.com/Redocly/redoc#redoc-theme-object
+       */
+      redocTheme: {},
     },
   },
 ];


### PR DESCRIPTION
Hey !

I spent a little bit of time on your lib. It's cool, great work !

I added an attribute inside docusaurus.config file, named `redocTheme`, to allow deep modification of the redoc theme.
I'm open if you have something else in your mind for this var.

I also lint the project so the file `/home/leo/CS/rs-dev/redocusaurus/packages/docusaurus-theme-redoc/src/theme/ServerStyle/index.tsx` is also bringed by this PR.

## Some notes
You should note that `nodemon` [is used in your package.json](https://github.com/rohit-gohri/redocusaurus/blob/main/packages/docusaurus-theme-redoc/package.json#L8) but is not inside dev dependencies.
But anyway, the command `yarn dev` is not working on my side, I have no output...
![image](https://user-images.githubusercontent.com/2767218/155600960-8340a14e-b118-4e14-911a-ba23b8edbdd2.png)
When I hit Ctrl+C it shows the log : 
![image](https://user-images.githubusercontent.com/2767218/155601033-f7297662-b6b2-4f95-8f52-d582e03dcda4.png)
Hopefully `yarn build` is OK.

I first tryed to develop this feature using my real Webapp with symlink to your modules, but it was hell :fire:. So I will wait you accept and publish this PR

---

Maintainer notes:
Closes #98 