### PR TITLE
feat(theme): improve Redoc component to display it in full size when used in MDX file

### DIFF
--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx
@@ -1,8 +1,7 @@
-import React, { useMemo } from 'react';
-import { usePluginData } from '@docusaurus/useGlobalData';
-import { useColorMode } from '@docusaurus/theme-common';
-import { Redoc as RedocComponent, RedocStandalone, AppStore } from 'redoc';
-import { RedocProps as Props, GlobalData } from '../../types/common';
+import React from 'react';
+import { Redoc as RedocComponent, RedocStandalone } from 'redoc';
+import { RedocProps } from '../../types/common';
+import useRedocHook from './RedocHook';
 import './styles.css';
 
 /*!
@@ -11,24 +10,11 @@ import './styles.css';
  * (c) 2021 Rohit Gohri
  * Released under the MIT License
  */
-function Redoc(props: Props): JSX.Element {
-  const { isDarkTheme } = useColorMode();
-  const { lightTheme, darkTheme, redocOptions } = usePluginData<GlobalData>(
-    'docusaurus-theme-redoc',
-  );
-  const theme = isDarkTheme ? darkTheme : lightTheme;
+function Redoc(props: RedocProps): JSX.Element {
   const { spec, specUrl } = props;
-  const store = useMemo(() => {
-    if (!spec) return null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return new AppStore(spec as any, specUrl, {
-      ...redocOptions,
-      theme,
-    });
-  }, [spec, specUrl, redocOptions, theme]);
-
+  const { wrapperClassName, store, redocOptions, theme } = useRedocHook(props);
   return (
-    <div className="redocusaurus">
+    <div className={wrapperClassName}>
       {store ? (
         <RedocComponent store={store} />
       ) : (

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/RedocHook.ts
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/RedocHook.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { usePluginData } from '@docusaurus/useGlobalData';
+import { useColorMode } from '@docusaurus/theme-common';
+import { AppStore } from 'redoc';
+import { RedocProps, GlobalData } from '../../types/common';
+
+/*!
+ * Redocusaurus
+ * https://rohit-gohri.github.io/redocusaurus/
+ * (c) 2021 Rohit Gohri
+ * Released under the MIT License
+ */
+const useRedocHook = (props: RedocProps) => {
+  const { isDarkTheme } = useColorMode();
+  const { lightTheme, darkTheme, redocOptions } = usePluginData<GlobalData>(
+    'docusaurus-theme-redoc',
+  );
+  const theme = isDarkTheme ? darkTheme : lightTheme;
+  const { spec, specUrl, fullscreenWithSidebar } = props;
+  const store = useMemo(() => {
+    if (!spec) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new AppStore(spec as any, specUrl, {
+      ...redocOptions,
+      theme,
+    });
+  }, [spec, specUrl, redocOptions, theme]);
+  const classNames = ['redocusaurus'];
+  if (fullscreenWithSidebar) {
+    classNames.push('redocusaurus-fullscreen-with-sidebar');
+  }
+  const wrapperClassName = classNames.join(' ')
+
+  return { wrapperClassName, store, redocOptions, theme };
+};
+
+export default useRedocHook;

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
@@ -1,3 +1,12 @@
+/* ------ Hacky solution to display redoc in full size inside a doc page with an existing sidebar ------- */
+
+@media (min-width: 1600px) {
+  .redocusaurus-fullscreen-with-sidebar {
+    width: calc(97vw - var(--doc-sidebar-width));
+    margin-left: calc((98vw - (var(--doc-sidebar-width) + var(--ifm-container-width-xl))) / -2);
+  }
+}
+
 .redocusaurus .redoc-wrap {
   border-bottom: 1px solid var(--ifm-toc-border-color);
 }

--- a/packages/docusaurus-theme-redoc/src/types/common.ts
+++ b/packages/docusaurus-theme-redoc/src/types/common.ts
@@ -5,6 +5,7 @@ import type { RecursivePartial } from './util';
 export type RedocProps = {
   spec?: Record<string, unknown>;
   specUrl?: string;
+  fullscreenWithSidebar?: boolean;
 };
 
 export type ApiSchemaProps = Omit<


### PR DESCRIPTION
Refactor that component to extract an hook file : http://regardsoss.github.io/docs/development/backend/services/catalog/api-swagger/

And introduce a new param named `fullscreenWithSidebar` inside `RedocProps`. When true, it sets a special class that fix layout of Redoc to get it in full size.
It should looks lilke http://regardsoss.github.io/docs/development/backend/services/catalog/api-swagger