### PR TITLE
Add ChatKitty to Who is using Redocusaurus

### DIFF
--- a/website/docs/who-is-using-redocusaurus.md
+++ b/website/docs/who-is-using-redocusaurus.md
@@ -6,6 +6,7 @@ sidebar_position: 5
 
 Feel free to add your site below by sending a Pull Request! (sort in alphabetical order)
 
+- [ChatKitty API Docs](https://chatkitty.com/docs/rest/reference)
 - [Forem API Docs](https://developers.forem.com/api)
 - [Regards OSS](http://regardsoss.github.io/) - [example](http://regardsoss.github.io/docs/development/backend/services/catalog/api-swagger)
 - [Wechaty OpenAPI](https://wechaty.js.org/docs/openapi/)


### PR DESCRIPTION
Adds chatkitty.com to /docs/who-is-using-redocusaurus