### PR TITLE
Fix ScrollYOffset reset when not using a selector

### DIFF
--- a/.changeset/fuzzy-panthers-wink.md
+++ b/.changeset/fuzzy-panthers-wink.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-theme-redoc': patch
+---
+
+fix scrollYOffset disable when not using selector

--- a/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
+++ b/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
@@ -24,8 +24,11 @@ export function useSpec({ spec, url }: SpecProps) {
     const { lightTheme, darkTheme, options: redocOptions } = themeOptions;
 
     const commonOptions: Partial<RedocRawOptions> = {
-      // Disable offset when server rendering
-      scrollYOffset: isBrowser ? redocOptions.scrollYOffset : 0,
+      // Disable offset when server rendering and set to selector
+      scrollYOffset:
+        !isBrowser && typeof redocOptions.scrollYOffset === 'string'
+          ? 0
+          : redocOptions.scrollYOffset,
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This change keeps the existing logic for setting scrollYOffset to 0 when a selector is used to prevent the redoc warning.  But it no longer sets the offset to 0 if using a number of function.

Fix for https://github.com/rohit-gohri/redocusaurus/issues/162
