### PR TITLE
fix(theme): dark and light AppStore menu fix

### DIFF
--- a/packages/docusaurus-theme-redoc/src/theme/ApiSchema/ApiSchema.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/ApiSchema/ApiSchema.tsx
@@ -16,15 +16,14 @@ const ApiSchema: React.FC<Props> = ({
   ...rest
 }: Props): JSX.Element => {
   const specProps = useSpecData(id);
-  const { store, darkStore, lightStore } = useSpec(specProps);
+  const { store } = useSpec(specProps);
 
   useEffect(() => {
     /**
      * @see https://github.com/Redocly/redoc/blob/823be24b313c3a2445df7e0801a0cc79c20bacd1/src/services/MenuStore.ts#L273-L276
      */
-    lightStore.menu.dispose();
-    darkStore.menu.dispose();
-  }, [lightStore, darkStore]);
+    store.menu.dispose();
+  }, [store]);
 
   return (
     <ThemeProvider theme={store.options.theme}>

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx
@@ -20,14 +20,18 @@ function Redoc(
   },
 ): JSX.Element {
   const { className, optionsOverrides, ...specProps } = props;
-  const { store, darkStore, lightStore, hasLogo } = useSpec(
+  const { store, darkThemeOptions, lightThemeOptions, hasLogo } = useSpec(
     specProps,
     optionsOverrides,
   );
 
   return (
     <>
-      <ServerStyles lightStore={lightStore} darkStore={darkStore} />
+      <ServerStyles
+        store={store}
+        lightThemeOptions={lightThemeOptions}
+        darkThemeOptions={darkThemeOptions}
+      />
       <div
         className={clsx([
           'redocusaurus',

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerStyles.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerStyles.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '../../global';
-import { AppStore, Redoc } from 'redoc';
+import { AppStore, Redoc, RedocRawOptions, RedocNormalizedOptions } from 'redoc';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { renderToString } from 'react-dom/server';
 import { ServerStyleSheet } from 'styled-components';
@@ -53,19 +53,22 @@ const LIGHT_MODE_PREFIX = "html:not([data-theme='dark'])";
 const DARK_MODE_PREFIX = "html([data-theme='dark'])";
 
 export function ServerStyles({
-  lightStore,
-  darkStore,
+  store,
+  lightThemeOptions,
+  darkThemeOptions,
 }: {
-  lightStore: AppStore;
-  darkStore: AppStore;
+  store: AppStore,
+  lightThemeOptions: RedocRawOptions,
+  darkThemeOptions: RedocRawOptions,
 }) {
   const css = {
     light: '',
     dark: '',
   };
   const lightSheet = new ServerStyleSheet();
+  store.options = new RedocNormalizedOptions(lightThemeOptions);
   renderToString(
-    lightSheet.collectStyles(React.createElement(Redoc, { store: lightStore })),
+    lightSheet.collectStyles(React.createElement(Redoc, { store })),
   );
   const lightStyleTag = lightSheet.getStyleTags();
   let lightCss = lightStyleTag.slice(lightStyleTag.indexOf('>') + 1);
@@ -73,8 +76,9 @@ export function ServerStyles({
   css.light = prefixCssSelectors(lightCss, LIGHT_MODE_PREFIX);
 
   const darkSheet = new ServerStyleSheet();
+  store.options = new RedocNormalizedOptions(darkThemeOptions);
   renderToString(
-    darkSheet.collectStyles(React.createElement(Redoc, { store: darkStore })),
+    darkSheet.collectStyles(React.createElement(Redoc, { store })),
   );
   const darkStyleTag = darkSheet.getStyleTags();
   let darkCss = darkStyleTag.slice(darkStyleTag.indexOf('>') + 1);

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/Styles.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/Styles.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import '../../global';
-import type { AppStore } from 'redoc';
+import type { AppStore, RedocRawOptions } from 'redoc';
 
 /**
  * Don't hydrate/replace server styles
  * @see https://github.com/facebook/react/issues/10923#issuecomment-338715787
  */
 export function ServerStyles(_props: {
-  lightStore: AppStore;
-  darkStore: AppStore;
+  store: AppStore,
+  lightThemeOptions: RedocRawOptions,
+  darkThemeOptions: RedocRawOptions,
 }) {
   return <div className="redocusaurus-styles"></div>;
 }

--- a/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
+++ b/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
@@ -27,7 +27,7 @@ export function useSpec(
     themeId,
   ) as GlobalData;
 
-  const stores = useMemo(() => {
+  const result = useMemo(() => {
     const { lightTheme, darkTheme, options: redocOptions } = themeOptions;
 
     const commonOptions: Partial<RedocRawOptions> = {
@@ -38,48 +38,39 @@ export function useSpec(
           : redocOptions.scrollYOffset,
     };
 
-    const lightStore = new AppStore(
+    const lightThemeOptions: RedocRawOptions = merge(
+      {
+        ...redocOptions,
+        ...commonOptions,
+        theme: lightTheme,
+      },
+      optionsOverrides,
+    );
+
+    const darkThemeOptions: RedocRawOptions = merge(
+      {
+        ...redocOptions,
+        ...commonOptions,
+        theme: darkTheme,
+      },
+      optionsOverrides,
+    );
+
+    const store = new AppStore(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       spec as any,
       fullUrl,
-      merge(
-        {
-          ...redocOptions,
-          ...commonOptions,
-          theme: lightTheme,
-        },
-        optionsOverrides,
-      ),
-    );
-
-    const darkStore = new AppStore(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      spec as any,
-      fullUrl,
-      merge(
-        {
-          ...redocOptions,
-          ...commonOptions,
-          theme: darkTheme,
-        },
-        optionsOverrides,
-      ),
+      isBrowser && isDarkTheme ? darkThemeOptions : lightThemeOptions,
     );
 
     return {
-      lightStore,
-      darkStore,
-    };
-  }, [isBrowser, spec, fullUrl, themeOptions, optionsOverrides]);
-
-  const result = useMemo(() => {
-    return {
-      ...stores,
+      darkThemeOptions,
+      lightThemeOptions,
       // @ts-expect-error extra prop
       hasLogo: !!spec.info?.['x-logo'],
-      store: isBrowser && isDarkTheme ? stores.darkStore : stores.lightStore,
+      store,
     };
-  }, [isBrowser, isDarkTheme, spec, stores]);
+  }, [isBrowser, isDarkTheme, spec, fullUrl, themeOptions, optionsOverrides]);
 
   return result;
 }


### PR DESCRIPTION
Fixes #172
Fixes #173
Fixes #169

Hi @rohit-gohri, thanks for this amazing plugin. I noticed the issues described in those issues filed and am proposing a fix. 

The issue was because we are initiating 2 copies of `AppStore`: one for dark and one for light. The last copy of `AppStore` successfully binds various scroll events to the window and hence was the only one able to receive the event. When in light theme, this doesn't work. I understood from the code that the 2 copies of `AppStore` were meant for `ServerStyles` to generate the dark and light stylesheets correctly.

I propose to only initiate 1 copy of `AppStore` and depending on the theme, update the `options` accordingly. 

Feel free to clarify on the changes proposed. If this is alright, I'd like this fix to be published as soon as possible. 