### PR TITLE
Don't dispose store in SSR

### DIFF
--- a/.changeset/spicy-eels-sleep.md
+++ b/.changeset/spicy-eels-sleep.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-theme-redoc': patch
+---
+
+Fix worker.terminate error in SSR

--- a/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
+++ b/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
@@ -59,9 +59,10 @@ export function useSpec(
       optionsOverrides,
     );
 
-    if (currentStore !== null) {
+    if (currentStore !== null && isBrowser) {
       currentStore.dispose();
     }
+
     currentStore = new AppStore(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       spec as any,


### PR DESCRIPTION
Closes  #209

Terminate isn't available in server and it's called on dispose here:
https://github.com/Redocly/redoc/blob/4fb5f914fa4fe05ee8b24cc15cb485f7b3538538/src/services/SearchStore.ts#L12-L14