### PR TITLE
update paths to watch for handling multi-file OpenAPI docs

### DIFF
--- a/.changeset/small-poets-sing.md
+++ b/.changeset/small-poets-sing.md
@@ -1,0 +1,5 @@
+---
+"docusaurus-plugin-redoc": patch
+---
+
+Update paths to watch for handling multi-file OpenAPI docs

--- a/packages/docusaurus-plugin-redoc/src/index.ts
+++ b/packages/docusaurus-plugin-redoc/src/index.ts
@@ -46,6 +46,7 @@ export default function redocPlugin(
     'redocusaurus',
     `${options.id || 'api-spec'}.yaml`,
   );
+  let filesToWatch: string[] = isSpecFile ? [path.resolve(spec)] : [];
 
   if (debug) {
     console.error('[REDOCUSAURUS_PLUGIN] Opts Input:', opts);
@@ -86,10 +87,15 @@ export default function redocPlugin(
         redoclyConfig = await loadConfig();
       }
 
-      const { bundle: bundledSpec, problems } = await bundle({
+      const {
+        bundle: bundledSpec,
+        problems,
+        fileDependencies,
+      } = await bundle({
         ref: spec,
         config: redoclyConfig,
       });
+      filesToWatch = [...fileDependencies];
 
       if (problems?.length) {
         console.error('[REDOCUSAURUS_PLUGIN] errors while bundling spec', spec);
@@ -181,10 +187,7 @@ export default function redocPlugin(
       fs.writeFileSync(staticFile, bundledYaml);
     },
     getPathsToWatch() {
-      if (!isSpecFile) {
-        return [];
-      }
-      return [path.resolve(spec)];
+      return filesToWatch;
     },
   };
 }

--- a/packages/docusaurus-plugin-redoc/src/index.ts
+++ b/packages/docusaurus-plugin-redoc/src/index.ts
@@ -95,7 +95,8 @@ export default function redocPlugin(
         ref: spec,
         config: redoclyConfig,
       });
-      filesToWatch = [...fileDependencies];
+
+      filesToWatch = [path.resolve(spec), ...fileDependencies];
 
       if (problems?.length) {
         console.error('[REDOCUSAURUS_PLUGIN] errors while bundling spec', spec);
@@ -187,6 +188,9 @@ export default function redocPlugin(
       fs.writeFileSync(staticFile, bundledYaml);
     },
     getPathsToWatch() {
+      if (!isSpecFile) {
+        return [];
+      }
       return filesToWatch;
     },
   };


### PR DESCRIPTION
Implements #213 

The `bundle` function in `@redocly/openapi-core` package provides the property `fileDependencies`, where it can be used to provide to Docusaurus through `getPathsToWatch()` a list of files to watch for changes because they are referenced from the main OpenAPI file through `$ref` references.

However changes to the list of files watched does not get updated by Docusaurus while running. 

Test case:

1. Run the example site in dev using `yarn dev`
1. make changes in `website/openapi/multi-file/components/pets.yaml`
1. hot reload occurs and changes show up on example site 
