### PR TITLE
chore(deps): Add webpack to peer dependencies of redoc theme

### DIFF
--- a/.changeset/hungry-tools-buy.md
+++ b/.changeset/hungry-tools-buy.md
@@ -1,0 +1,6 @@
+---
+"docusaurus-theme-redoc": patch
+"redocusaurus": patch
+---
+
+chore(deps): Add webpack to peer dependencies of redoc theme, this fixes issue #322

--- a/packages/docusaurus-theme-redoc/package.json
+++ b/packages/docusaurus-theme-redoc/package.json
@@ -59,7 +59,8 @@
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
-    "@docusaurus/theme-common": "^3.0.0"
+    "@docusaurus/theme-common": "^3.0.0",
+    "webpack": "^5.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/redocusaurus/package.json
+++ b/packages/redocusaurus/package.json
@@ -52,6 +52,7 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "webpack": "^5.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6427,6 +6427,7 @@ __metadata:
     typescript: "npm:^5.2.2"
   peerDependencies:
     "@docusaurus/theme-common": ^3.0.0
+    webpack: ^5.0.0
   languageName: unknown
   linkType: soft
 
@@ -13321,6 +13322,7 @@ __metadata:
     docusaurus-plugin-redoc: "npm:2.0.0"
     docusaurus-theme-redoc: "npm:2.0.0"
     typescript: "npm:^5.2.2"
+    webpack: "npm:^5.0.0"
   peerDependencies:
     "@docusaurus/theme-common": ^3.0.0
     "@docusaurus/utils": ^3.0.0
@@ -15836,7 +15838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.88.1":
+"webpack@npm:^5.0.0, webpack@npm:^5.88.1":
   version: 5.89.0
   resolution: "webpack@npm:5.89.0"
   dependencies:


### PR DESCRIPTION
This fixes #322 

Adding webpack to the peer dependencies correctly resolves this package to Webpack 5, which is requires for redoc 4.