### PR TITLE
fix redocly available props link doc

### DIFF
--- a/website/docs/getting-started/theme-options.md
+++ b/website/docs/getting-started/theme-options.md
@@ -35,7 +35,7 @@ Deprecated: Use `redocly.yaml` to specify `theme.options`. See [example](https:/
 
 Override redoc options passed to [RedocStandalone](https://redoc.ly/docs/redoc/quickstart/react/) component. See the defaults [here](https://github.com/rohit-gohri/redocusaurus/blob/main/packages/docusaurus-theme-redoc/src/redocData.ts#L5-L12).
 
-Available properties [here](https://redocly.com/docs/api-reference-docs/configuration/functionality/#featuresopenapi-schema).  
+Available properties [here](https://redocly.com/docs/redoc/config/).  
 
 You cannot set theme property using this property, use `theme` option above instead.
 

--- a/website/redocly.yaml
+++ b/website/redocly.yaml
@@ -8,7 +8,7 @@ rules:
   no-unused-components: error
 
 theme:
-  # See https://redocly.com/docs/api-reference-docs/configuration/functionality/
+  # See https://redocly.com/docs/redoc/config/
   openapi:
     disableSearch: true
     # See https://redocly.com/docs/api-reference-docs/configuration/theming/


### PR DESCRIPTION
There is a new page on the documentation of redocly that provides the list of props available on the free version.

The old link provides more props but not available on free version