### PR TITLE
Upgrade Docusaurus - enable Docusaurus Faster

### DIFF
--- a/.changeset/small-ligers-doubt.md
+++ b/.changeset/small-ligers-doubt.md
@@ -1,0 +1,6 @@
+---
+"docusaurus-theme-redoc": minor
+"redocusaurus": patch
+---
+
+Upgrade Docusaurus - add support for Docusaurus Faster (RsPack)

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ static/openapi
 .pnp.*
 
 website/version.json
+
+.idea

--- a/packages/docusaurus-plugin-redoc/package.json
+++ b/packages/docusaurus-plugin-redoc/package.json
@@ -33,8 +33,8 @@
     "redoc": "2.1.5"
   },
   "devDependencies": {
-    "@docusaurus/types": "^3.4.0",
-    "@docusaurus/utils": "^3.4.0",
+    "@docusaurus/types": "3.5.2-canary-6122",
+    "@docusaurus/utils": "3.5.2-canary-6122",
     "core-js": "^3.36.0",
     "mobx": "^6.12.4",
     "react": "^18.3.1",

--- a/packages/docusaurus-plugin-redoc/package.json
+++ b/packages/docusaurus-plugin-redoc/package.json
@@ -33,8 +33,8 @@
     "redoc": "2.1.5"
   },
   "devDependencies": {
-    "@docusaurus/types": "3.5.2-canary-6125",
-    "@docusaurus/utils": "3.5.2-canary-6125",
+    "@docusaurus/types": "^3.6.0",
+    "@docusaurus/utils": "^3.6.0",
     "core-js": "^3.36.0",
     "mobx": "^6.12.4",
     "react": "^18.3.1",

--- a/packages/docusaurus-plugin-redoc/package.json
+++ b/packages/docusaurus-plugin-redoc/package.json
@@ -33,8 +33,8 @@
     "redoc": "2.1.5"
   },
   "devDependencies": {
-    "@docusaurus/types": "3.5.2-canary-6122",
-    "@docusaurus/utils": "3.5.2-canary-6122",
+    "@docusaurus/types": "3.5.2-canary-6125",
+    "@docusaurus/utils": "3.5.2-canary-6125",
     "core-js": "^3.36.0",
     "mobx": "^6.12.4",
     "react": "^18.3.1",

--- a/packages/docusaurus-theme-redoc/package.json
+++ b/packages/docusaurus-theme-redoc/package.json
@@ -42,10 +42,10 @@
     "styled-components": "^6.1.11"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.4.0",
-    "@docusaurus/theme-classic": "^3.4.0",
-    "@docusaurus/theme-common": "^3.4.0",
-    "@docusaurus/types": "^3.4.0",
+    "@docusaurus/module-type-aliases": "3.5.2-canary-6122",
+    "@docusaurus/theme-classic": "3.5.2-canary-6122",
+    "@docusaurus/theme-common": "3.5.2-canary-6122",
+    "@docusaurus/types": "3.5.2-canary-6122",
     "@types/lodash": "^4.14.200",
     "@types/postcss-prefix-selector": "^1",
     "@types/react": "^18.3.3",

--- a/packages/docusaurus-theme-redoc/package.json
+++ b/packages/docusaurus-theme-redoc/package.json
@@ -42,10 +42,10 @@
     "styled-components": "^6.1.11"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.5.2-canary-6122",
-    "@docusaurus/theme-classic": "3.5.2-canary-6122",
-    "@docusaurus/theme-common": "3.5.2-canary-6122",
-    "@docusaurus/types": "3.5.2-canary-6122",
+    "@docusaurus/module-type-aliases": "3.5.2-canary-6125",
+    "@docusaurus/theme-classic": "3.5.2-canary-6125",
+    "@docusaurus/theme-common": "3.5.2-canary-6125",
+    "@docusaurus/types": "3.5.2-canary-6125",
     "@types/lodash": "^4.14.200",
     "@types/postcss-prefix-selector": "^1",
     "@types/react": "^18.3.3",

--- a/packages/docusaurus-theme-redoc/package.json
+++ b/packages/docusaurus-theme-redoc/package.json
@@ -42,10 +42,10 @@
     "styled-components": "^6.1.11"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.5.2-canary-6125",
-    "@docusaurus/theme-classic": "3.5.2-canary-6125",
-    "@docusaurus/theme-common": "3.5.2-canary-6125",
-    "@docusaurus/types": "3.5.2-canary-6125",
+    "@docusaurus/module-type-aliases": "^3.6.0",
+    "@docusaurus/theme-classic": "^3.6.0",
+    "@docusaurus/theme-common": "^3.6.0",
+    "@docusaurus/types": "^3.6.0",
     "@types/lodash": "^4.14.200",
     "@types/postcss-prefix-selector": "^1",
     "@types/react": "^18.3.3",

--- a/packages/docusaurus-theme-redoc/src/index.ts
+++ b/packages/docusaurus-theme-redoc/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { LoadContext, Plugin } from '@docusaurus/types';
-import { ThemeOptions, GlobalData } from './types/options';
+import type { ThemeOptions, GlobalData } from './types/options';
 import { getGlobalData } from './redocData';
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/order

--- a/packages/docusaurus-theme-redoc/src/index.ts
+++ b/packages/docusaurus-theme-redoc/src/index.ts
@@ -4,7 +4,6 @@ import { ThemeOptions, GlobalData } from './types/options';
 import { getGlobalData } from './redocData';
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/order
-import webpack from 'webpack';
 
 export type { ThemeOptions, GlobalData };
 
@@ -14,14 +13,15 @@ export default function redocTheme(
 ): Plugin<null> {
   return {
     name: 'docusaurus-theme-redoc',
-    configureWebpack(_config, isServer) {
+    configureWebpack(_config, isServer,{currentBundler}) {
+      const bundler = currentBundler.instance ?? require("webpack")
       return {
         plugins: [
-          new webpack.NormalModuleReplacementPlugin(
+          new bundler.NormalModuleReplacementPlugin(
             /^tty$/,
             require.resolve('./tty'),
           ),
-          new webpack.DefinePlugin({
+          new bundler.DefinePlugin({
             'process.versions.node': JSON.stringify(
               process.versions.node || '0.0.0',
             ),
@@ -33,7 +33,7 @@ export default function redocTheme(
           }),
           ...(isServer
             ? [
-                new webpack.NormalModuleReplacementPlugin(
+                new bundler.NormalModuleReplacementPlugin(
                   /theme\/Redoc\/Styles/,
                   path.join(__dirname, 'theme', 'Redoc', 'ServerStyles.js'),
                 ),

--- a/packages/docusaurus-theme-redoc/src/redocData.ts
+++ b/packages/docusaurus-theme-redoc/src/redocData.ts
@@ -1,7 +1,11 @@
 import type { RedocRawOptions } from 'redoc';
 import merge from 'lodash/merge';
 import { Config, loadConfig } from '@redocly/openapi-core';
-import type { GlobalData, RedocThemeOverrides, ThemeOptions } from './types/options';
+import type {
+  GlobalData,
+  RedocThemeOverrides,
+  ThemeOptions,
+} from './types/options';
 
 const defaultOptions: Partial<RedocRawOptions> = {
   scrollYOffset: 'nav.navbar',

--- a/packages/docusaurus-theme-redoc/src/redocData.ts
+++ b/packages/docusaurus-theme-redoc/src/redocData.ts
@@ -1,7 +1,7 @@
 import type { RedocRawOptions } from 'redoc';
 import merge from 'lodash/merge';
 import { Config, loadConfig } from '@redocly/openapi-core';
-import { GlobalData, RedocThemeOverrides, ThemeOptions } from './types/options';
+import type { GlobalData, RedocThemeOverrides, ThemeOptions } from './types/options';
 
 const defaultOptions: Partial<RedocRawOptions> = {
   scrollYOffset: 'nav.navbar',

--- a/packages/docusaurus-theme-redoc/src/theme/ApiDoc/ApiDoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/ApiDoc/ApiDoc.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Layout from '@theme/Layout';
 import Redoc from '@theme/Redoc';
-import { ApiDocProps as Props } from '../../types/common';
+import type { ApiDocProps as Props } from '../../types/common';
 
 function ApiDoc({ layoutProps, specProps }: Props): JSX.Element {
   const defaultTitle = specProps.spec?.info?.title || 'API Docs';

--- a/packages/docusaurus-theme-redoc/src/theme/ApiDocMdx/ApiDocMdx.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/ApiDocMdx/ApiDocMdx.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import Redoc from '@theme/Redoc';
 import useSpecData from '@theme/useSpecData';
-import { MdxProps as Props } from '../../types/common';
+import type { MdxProps as Props } from '../../types/common';
 import '../ApiSchema/styles.css';
 
 const ApiDocMdx: React.FC<Props> = ({ id }: Props): JSX.Element => {

--- a/packages/docusaurus-theme-redoc/src/theme/ApiSchema/ApiSchema.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/ApiSchema/ApiSchema.tsx
@@ -5,7 +5,7 @@ import '../../global';
 import { SchemaDefinition } from 'redoc';
 import { useSpec } from '../../utils/useSpec';
 import { useSpecData } from '../useSpecData';
-import { ApiSchemaProps as Props } from '../../types/common';
+import type { ApiSchemaProps as Props } from '../../types/common';
 import '../Redoc/styles.css';
 import './styles.css';
 

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/Redoc.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import '../../global';
 import { RedocStandalone, RedocRawOptions } from 'redoc';
-import { SpecProps } from '../../types/common';
+import type { SpecProps } from '../../types/common';
 import { useSpecOptions } from '../../utils/useSpecOptions';
 import './styles.css';
 import ServerRedoc from './ServerRedoc';

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerRedoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerRedoc.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import '../../global';
 import { Redoc as RedocComponent, RedocRawOptions } from 'redoc';
-import { SpecProps } from '../../types/common';
+import type { SpecProps } from '../../types/common';
 import { useSpec } from '../../utils/useSpec';
 import { ServerStyles } from './Styles';
 import './styles.css';

--- a/packages/docusaurus-theme-redoc/src/theme/useSpecData.ts
+++ b/packages/docusaurus-theme-redoc/src/theme/useSpecData.ts
@@ -1,5 +1,5 @@
 import { useAllPluginInstancesData } from '@docusaurus/useGlobalData';
-import { SpecProps } from '../types/common';
+import type { SpecProps } from '../types/common';
 
 /**
  *

--- a/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
+++ b/packages/docusaurus-theme-redoc/src/utils/useSpec.ts
@@ -4,7 +4,7 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import { useColorMode } from '@docusaurus/theme-common';
 import '../global';
 import { AppStore, RedocRawOptions } from 'redoc';
-import { SpecProps } from '../types/common';
+import type { SpecProps } from '../types/common';
 import { useSpecOptions } from './useSpecOptions';
 
 // the current store singleton in the app's instance

--- a/packages/docusaurus-theme-redoc/src/utils/useSpecOptions.ts
+++ b/packages/docusaurus-theme-redoc/src/utils/useSpecOptions.ts
@@ -8,7 +8,7 @@ import { useColorMode } from '@docusaurus/theme-common';
 import merge from 'lodash/merge';
 import '../global';
 import type { RedocRawOptions } from 'redoc';
-import {type  SpecProps } from '../types/common';
+import type { SpecProps } from '../types/common';
 import { GlobalData } from '../types/options';
 
 /**

--- a/packages/docusaurus-theme-redoc/src/utils/useSpecOptions.ts
+++ b/packages/docusaurus-theme-redoc/src/utils/useSpecOptions.ts
@@ -7,8 +7,8 @@ import {
 import { useColorMode } from '@docusaurus/theme-common';
 import merge from 'lodash/merge';
 import '../global';
-import { RedocRawOptions } from 'redoc';
-import { SpecProps } from '../types/common';
+import type { RedocRawOptions } from 'redoc';
+import {type  SpecProps } from '../types/common';
 import { GlobalData } from '../types/options';
 
 /**

--- a/packages/redocusaurus/package.json
+++ b/packages/redocusaurus/package.json
@@ -52,8 +52,8 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@docusaurus/theme-common": "3.5.2-canary-6125",
-    "@docusaurus/utils": "3.5.2-canary-6125",
+    "@docusaurus/theme-common": "^3.6.0",
+    "@docusaurus/utils": "^3.6.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",

--- a/packages/redocusaurus/package.json
+++ b/packages/redocusaurus/package.json
@@ -52,8 +52,8 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@docusaurus/theme-common": "3.5.2-canary-6122",
-    "@docusaurus/utils": "3.5.2-canary-6122",
+    "@docusaurus/theme-common": "3.5.2-canary-6125",
+    "@docusaurus/utils": "3.5.2-canary-6125",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",

--- a/packages/redocusaurus/package.json
+++ b/packages/redocusaurus/package.json
@@ -52,8 +52,8 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@docusaurus/theme-common": "^3.4.0",
-    "@docusaurus/utils": "^3.4.0",
+    "@docusaurus/theme-common": "3.5.2-canary-6122",
+    "@docusaurus/utils": "3.5.2-canary-6122",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "react": "^18.3.1",

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: [require.resolve('@docusaurus/core/lib/babel/preset')],
-};

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,15 +11,7 @@ if (process.env.VERCEL_URL) {
 
 const config: Config = {
   future: {
-    // experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true',
-    experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true' ? {
-      rspackBundler: true,
-      swcJsLoader: false, // TODO :S
-      swcHtmlMinimizer: true,
-      swcJsMinimizer: true,
-      lightningCssMinimizer: true,
-      mdxCrossCompilerCache: true,
-    } : false,
+    experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true',
   },
   title: 'Redocusaurus',
   tagline: 'OpenAPI solution for Docusaurus docs with Redoc',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,7 +11,8 @@ if (process.env.VERCEL_URL) {
 
 const config: Config = {
   future: {
-    experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true',
+    // See https://docusaurus.io/blog/releases/3.6
+    experimental_faster: true,
   },
   title: 'Redocusaurus',
   tagline: 'OpenAPI solution for Docusaurus docs with Redoc',

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -10,6 +10,17 @@ if (process.env.VERCEL_URL) {
 }
 
 const config: Config = {
+  future: {
+    // experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true',
+    experimental_faster: {
+      rspackBundler: false,
+      swcJsLoader: false,
+      swcHtmlMinimizer: true,
+      swcJsMinimizer: true,
+      lightningCssMinimizer: true,
+      mdxCrossCompilerCache: true,
+    },
+  },
   title: 'Redocusaurus',
   tagline: 'OpenAPI solution for Docusaurus docs with Redoc',
   customFields: {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -12,14 +12,14 @@ if (process.env.VERCEL_URL) {
 const config: Config = {
   future: {
     // experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true',
-    experimental_faster: {
-      rspackBundler: false,
-      swcJsLoader: false,
+    experimental_faster: (process.env.DOCUSAURUS_FASTER ?? 'true') === 'true' ? {
+      rspackBundler: true,
+      swcJsLoader: false, // TODO :S
       swcHtmlMinimizer: true,
       swcJsMinimizer: true,
       lightningCssMinimizer: true,
       mdxCrossCompilerCache: true,
-    },
+    } : false,
   },
   title: 'Redocusaurus',
   tagline: 'OpenAPI solution for Docusaurus docs with Redoc',

--- a/website/package.json
+++ b/website/package.json
@@ -22,11 +22,11 @@
     "test": "percy snapshot snapshots.js"
   },
   "dependencies": {
-    "@docusaurus/core": "3.5.2-canary-6125",
-    "@docusaurus/faster": "3.5.2-canary-6125",
-    "@docusaurus/preset-classic": "3.5.2-canary-6125",
-    "@docusaurus/theme-common": "3.5.2-canary-6125",
-    "@docusaurus/utils": "3.5.2-canary-6125",
+    "@docusaurus/core": "3.6.0",
+    "@docusaurus/faster": "3.6.0",
+    "@docusaurus/preset-classic": "3.6.0",
+    "@docusaurus/theme-common": "3.6.0",
+    "@docusaurus/utils": "3.6.0",
     "clsx": "^1.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/website/package.json
+++ b/website/package.json
@@ -22,11 +22,11 @@
     "test": "percy snapshot snapshots.js"
   },
   "dependencies": {
-    "@docusaurus/core": "3.6.0",
-    "@docusaurus/faster": "3.6.0",
-    "@docusaurus/preset-classic": "3.6.0",
-    "@docusaurus/theme-common": "3.6.0",
-    "@docusaurus/utils": "3.6.0",
+    "@docusaurus/core": "^3.6.0",
+    "@docusaurus/faster": "^3.6.0",
+    "@docusaurus/preset-classic": "^3.6.0",
+    "@docusaurus/theme-common": "^3.6.0",
+    "@docusaurus/utils": "^3.6.0",
     "clsx": "^1.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/website/package.json
+++ b/website/package.json
@@ -22,10 +22,11 @@
     "test": "percy snapshot snapshots.js"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/preset-classic": "^3.4.0",
-    "@docusaurus/theme-common": "^3.4.0",
-    "@docusaurus/utils": "^3.4.0",
+    "@docusaurus/core": "3.5.2-canary-6122",
+    "@docusaurus/faster": "3.5.2-canary-6122",
+    "@docusaurus/preset-classic": "3.5.2-canary-6122",
+    "@docusaurus/theme-common": "3.5.2-canary-6122",
+    "@docusaurus/utils": "3.5.2-canary-6122",
     "clsx": "^1.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/website/package.json
+++ b/website/package.json
@@ -22,11 +22,11 @@
     "test": "percy snapshot snapshots.js"
   },
   "dependencies": {
-    "@docusaurus/core": "3.5.2-canary-6122",
-    "@docusaurus/faster": "3.5.2-canary-6122",
-    "@docusaurus/preset-classic": "3.5.2-canary-6122",
-    "@docusaurus/theme-common": "3.5.2-canary-6122",
-    "@docusaurus/utils": "3.5.2-canary-6122",
+    "@docusaurus/core": "3.5.2-canary-6125",
+    "@docusaurus/faster": "3.5.2-canary-6125",
+    "@docusaurus/preset-classic": "3.5.2-canary-6125",
+    "@docusaurus/theme-common": "3.5.2-canary-6125",
+    "@docusaurus/utils": "3.5.2-canary-6125",
     "clsx": "^1.2.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/code-frame@npm:7.26.0"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.0.0"
+  checksum: 41deb0a9ac72d81e46aeab7e587a75e46c7af6a717e10b150a150b332e843807eacb7c856832c84bee2c5015fe31de23e04c18e052c83a1254027c71c0840791
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/compat-data@npm:7.24.7"
@@ -221,7 +232,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.21.3, @babel/core@npm:^7.23.3":
+"@babel/compat-data@npm:^7.25.9, @babel/compat-data@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/compat-data@npm:7.26.0"
+  checksum: e847d58222eb567da4bcc2c8e4e44b508d1a34626922858fe12edeb73b5f3c486e7e77a351725b4347525d623dc5046b8a6355df76f368560ca6cbac10fef2c5
+  languageName: node
+  linkType: hard
+
+"@babel/core@npm:^7.21.3":
   version: 7.24.7
   resolution: "@babel/core@npm:7.24.7"
   dependencies:
@@ -244,7 +262,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.23.3, @babel/generator@npm:^7.24.7":
+"@babel/core@npm:^7.25.9":
+  version: 7.26.0
+  resolution: "@babel/core@npm:7.26.0"
+  dependencies:
+    "@ampproject/remapping": "npm:^2.2.0"
+    "@babel/code-frame": "npm:^7.26.0"
+    "@babel/generator": "npm:^7.26.0"
+    "@babel/helper-compilation-targets": "npm:^7.25.9"
+    "@babel/helper-module-transforms": "npm:^7.26.0"
+    "@babel/helpers": "npm:^7.26.0"
+    "@babel/parser": "npm:^7.26.0"
+    "@babel/template": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.26.0"
+    convert-source-map: "npm:^2.0.0"
+    debug: "npm:^4.1.0"
+    gensync: "npm:^1.0.0-beta.2"
+    json5: "npm:^2.2.3"
+    semver: "npm:^6.3.1"
+  checksum: 65767bfdb1f02e80d3af4f138066670ef8fdd12293de85ef151758a901c191c797e86d2e99b11c4cdfca33c72385ecaf38bbd7fa692791ec44c77763496b9b93
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/generator@npm:7.24.7"
   dependencies:
@@ -256,12 +297,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.25.9, @babel/generator@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/generator@npm:7.26.0"
+  dependencies:
+    "@babel/parser": "npm:^7.26.0"
+    "@babel/types": "npm:^7.26.0"
+    "@jridgewell/gen-mapping": "npm:^0.3.5"
+    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    jsesc: "npm:^3.0.2"
+  checksum: 3528b0b5da7003617771ddfc564bcb4037dde59e8142e3808ae8eb5d45c5dfda74df5eb9e6162ab2c2bc66329c609a44d9fd0ce6d4bc14b89b3deb92c3343c56
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.22.5, @babel/helper-annotate-as-pure@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-annotate-as-pure@npm:7.24.7"
   dependencies:
     "@babel/types": "npm:^7.24.7"
   checksum: a9017bfc1c4e9f2225b967fbf818004703de7cf29686468b54002ffe8d6b56e0808afa20d636819fcf3a34b89ba72f52c11bdf1d69f303928ee10d92752cad95
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-annotate-as-pure@npm:7.25.9"
+  dependencies:
+    "@babel/types": "npm:^7.25.9"
+  checksum: 41edda10df1ae106a9b4fe617bf7c6df77db992992afd46192534f5cff29f9e49a303231733782dd65c5f9409714a529f215325569f14282046e9d3b7a1ffb6c
   languageName: node
   linkType: hard
 
@@ -275,6 +338,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-builder-binary-assignment-operator-visitor@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-builder-binary-assignment-operator-visitor@npm:7.25.9"
+  dependencies:
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: e1bb465b3b0155702d82cfef09e3813e87a6d777cdd2c513796861eac14953340491eafea1d4109278bf4ceb48b54074c45758f042c0544d00c498090bee5a6f
+  languageName: node
+  linkType: hard
+
 "@babel/helper-compilation-targets@npm:^7.22.6, @babel/helper-compilation-targets@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-compilation-targets@npm:7.24.7"
@@ -285,6 +358,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: 8f8bc89af70a606ccb208513aa25d83e19b88f91b64a33174f7701a9479e67ddbb0a9c89033265070375cd24e690b93380b3a3ea11e4b3a711d742f0f4699ee7
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-compilation-targets@npm:7.25.9"
+  dependencies:
+    "@babel/compat-data": "npm:^7.25.9"
+    "@babel/helper-validator-option": "npm:^7.25.9"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 8053fbfc21e8297ab55c8e7f9f119e4809fa7e505268691e1bedc2cf5e7a5a7de8c60ad13da2515378621b7601c42e101d2d679904da395fa3806a1edef6b92e
   languageName: node
   linkType: hard
 
@@ -307,6 +393,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-create-class-features-plugin@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-member-expression-to-functions": "npm:^7.25.9"
+    "@babel/helper-optimise-call-expression": "npm:^7.25.9"
+    "@babel/helper-replace-supers": "npm:^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+    semver: "npm:^6.3.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: d1d47a7b5fd317c6cb1446b0e4f4892c19ddaa69ea0229f04ba8bea5f273fc8168441e7114ad36ff919f2d310f97310cec51adc79002e22039a7e1640ccaf248
+  languageName: node
+  linkType: hard
+
 "@babel/helper-create-regexp-features-plugin@npm:^7.18.6, @babel/helper-create-regexp-features-plugin@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-create-regexp-features-plugin@npm:7.24.7"
@@ -320,18 +423,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-define-polyfill-provider@npm:^0.4.3":
-  version: 0.4.3
-  resolution: "@babel/helper-define-polyfill-provider@npm:0.4.3"
+"@babel/helper-create-regexp-features-plugin@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-create-regexp-features-plugin@npm:7.25.9"
   dependencies:
-    "@babel/helper-compilation-targets": "npm:^7.22.6"
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-    debug: "npm:^4.1.1"
-    lodash.debounce: "npm:^4.0.8"
-    resolve: "npm:^1.14.2"
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    regexpu-core: "npm:^6.1.1"
+    semver: "npm:^6.3.1"
   peerDependencies:
-    "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 9ab9d6a2cfaffc44f8b7ad661b642b03f31597282557686b7f4c64f67acd3c5844d4eac028e63d238819bcec0549ddef7dc0539d10966ace96f4c61e97b33138
+    "@babel/core": ^7.0.0
+  checksum: bc2b6a365ddf490c416661833dbf4430ae0c66132acccb5ce257e82026dd9db54da788bfbdcb7e0032aa0cba965cb1be169b1e1fb2c8c029b81625da4963f6b9
   languageName: node
   linkType: hard
 
@@ -388,6 +489,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-member-expression-to-functions@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.25.9"
+  dependencies:
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: ef8cc1c1e600b012b312315f843226545a1a89f25d2f474ce2503fd939ca3f8585180f291a3a13efc56cf13eddc1d41a3a040eae9a521838fd59a6d04cc82490
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-imports@npm:^7.22.15, @babel/helper-module-imports@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-module-imports@npm:7.24.7"
@@ -395,6 +506,16 @@ __metadata:
     "@babel/traverse": "npm:^7.24.7"
     "@babel/types": "npm:^7.24.7"
   checksum: df8bfb2bb18413aa151ecd63b7d5deb0eec102f924f9de6bc08022ced7ed8ca7fed914562d2f6fa5b59b74a5d6e255dc35612b2bc3b8abf361e13f61b3704770
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-module-imports@npm:7.25.9"
+  dependencies:
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: e090be5dee94dda6cd769972231b21ddfae988acd76b703a480ac0c96f3334557d70a965bf41245d6ee43891e7571a8b400ccf2b2be5803351375d0f4e5bcf08
   languageName: node
   linkType: hard
 
@@ -413,6 +534,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-transforms@npm:^7.25.9, @babel/helper-module-transforms@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/helper-module-transforms@npm:7.26.0"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 9841d2a62f61ad52b66a72d08264f23052d533afc4ce07aec2a6202adac0bfe43014c312f94feacb3291f4c5aafe681955610041ece2c276271adce3f570f2f5
+  languageName: node
+  linkType: hard
+
 "@babel/helper-optimise-call-expression@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-optimise-call-expression@npm:7.24.7"
@@ -422,10 +556,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-optimise-call-expression@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-optimise-call-expression@npm:7.25.9"
+  dependencies:
+    "@babel/types": "npm:^7.25.9"
+  checksum: f09d0ad60c0715b9a60c31841b3246b47d67650c512ce85bbe24a3124f1a4d66377df793af393273bc6e1015b0a9c799626c48e53747581c1582b99167cc65dc
+  languageName: node
+  linkType: hard
+
 "@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.24.7, @babel/helper-plugin-utils@npm:^7.8.0, @babel/helper-plugin-utils@npm:^7.8.3":
   version: 7.24.7
   resolution: "@babel/helper-plugin-utils@npm:7.24.7"
   checksum: dad51622f0123fdba4e2d40a81a6b7d6ef4b1491b2f92fd9749447a36bde809106cf117358705057a2adc8fd73d5dc090222e0561b1213dae8601c8367f5aac8
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-plugin-utils@npm:7.25.9"
+  checksum: e347d87728b1ab10b6976d46403941c8f9008c045ea6d99997a7ffca7b852dc34b6171380f7b17edf94410e0857ff26f3a53d8618f11d73744db86e8ca9b8c64
   languageName: node
   linkType: hard
 
@@ -442,6 +592,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-remap-async-to-generator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-remap-async-to-generator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-wrap-function": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: ea37ad9f8f7bcc27c109963b8ebb9d22bac7a5db2a51de199cb560e251d5593fe721e46aab2ca7d3e7a24b0aa4aff0eaf9c7307af9c2fd3a1d84268579073052
+  languageName: node
+  linkType: hard
+
 "@babel/helper-replace-supers@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-replace-supers@npm:7.24.7"
@@ -455,6 +618,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-replace-supers@npm:7.25.9"
+  dependencies:
+    "@babel/helper-member-expression-to-functions": "npm:^7.25.9"
+    "@babel/helper-optimise-call-expression": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 8ebf787016953e4479b99007bac735c9c860822fafc51bc3db67bc53814539888797238c81fa8b948b6da897eb7b1c1d4f04df11e501a7f0596b356be02de2ab
+  languageName: node
+  linkType: hard
+
 "@babel/helper-simple-access@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-simple-access@npm:7.24.7"
@@ -465,6 +641,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-simple-access@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-simple-access@npm:7.25.9"
+  dependencies:
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: a16a6cfa5e8ac7144e856bcdaaf0022cf5de028fc0c56ce21dd664a6e900999a4285c587a209f2acf9de438c0d60bfb497f5f34aa34cbaf29da3e2f8d8d7feb7
+  languageName: node
+  linkType: hard
+
 "@babel/helper-skip-transparent-expression-wrappers@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.24.7"
@@ -472,6 +658,16 @@ __metadata:
     "@babel/traverse": "npm:^7.24.7"
     "@babel/types": "npm:^7.24.7"
   checksum: 784a6fdd251a9a7e42ccd04aca087ecdab83eddc60fda76a2950e00eb239cc937d3c914266f0cc476298b52ac3f44ffd04c358e808bd17552a7e008d75494a77
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.25.9"
+  dependencies:
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: fdbb5248932198bc26daa6abf0d2ac42cab9c2dbb75b7e9f40d425c8f28f09620b886d40e7f9e4e08ffc7aaa2cefe6fc2c44be7c20e81f7526634702fb615bdc
   languageName: node
   linkType: hard
 
@@ -491,6 +687,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-string-parser@npm:7.25.9"
+  checksum: c28656c52bd48e8c1d9f3e8e68ecafd09d949c57755b0d353739eb4eae7ba4f7e67e92e4036f1cd43378cc1397a2c943ed7bcaf5949b04ab48607def0258b775
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-identifier@npm:7.24.7"
@@ -498,10 +701,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-validator-identifier@npm:7.25.9"
+  checksum: 3f9b649be0c2fd457fa1957b694b4e69532a668866b8a0d81eabfa34ba16dbf3107b39e0e7144c55c3c652bf773ec816af8df4a61273a2bb4eb3145ca9cf478e
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.22.15, @babel/helper-validator-option@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helper-validator-option@npm:7.24.7"
   checksum: 9689166bf3f777dd424c026841c8cd651e41b21242dbfd4569a53086179a3e744c8eddd56e9d10b54142270141c91581b53af0d7c00c82d552d2540e2a919f7e
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-validator-option@npm:7.25.9"
+  checksum: 9491b2755948ebbdd68f87da907283698e663b5af2d2b1b02a2765761974b1120d5d8d49e9175b167f16f72748ffceec8c9cf62acfbee73f4904507b246e2b3d
   languageName: node
   linkType: hard
 
@@ -517,6 +734,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-wrap-function@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/helper-wrap-function@npm:7.25.9"
+  dependencies:
+    "@babel/template": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: 988dcf49159f1c920d6b9486762a93767a6e84b5e593a6342bc235f3e47cc1cb0c048d8fca531a48143e6b7fce1ff12ddbf735cf5f62cb2f07192cf7c27b89cf
+  languageName: node
+  linkType: hard
+
 "@babel/helpers@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/helpers@npm:7.24.7"
@@ -524,6 +752,16 @@ __metadata:
     "@babel/template": "npm:^7.24.7"
     "@babel/types": "npm:^7.24.7"
   checksum: f7496f0d7a0b13ea86136ac2053371027125734170328215f8a90eac96fafaaae4e5398c0729bdadf23261c00582a31e14bc70113427653b718220641a917f9d
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/helpers@npm:7.26.0"
+  dependencies:
+    "@babel/template": "npm:^7.25.9"
+    "@babel/types": "npm:^7.26.0"
+  checksum: fd4757f65d10b64cfdbf4b3adb7ea6ffff9497c53e0786452f495d1f7794da7e0898261b4db65e1c62bbb9a360d7d78a1085635c23dfc3af2ab6dcba06585f86
   languageName: node
   linkType: hard
 
@@ -548,6 +786,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.25.9, @babel/parser@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/parser@npm:7.26.0"
+  dependencies:
+    "@babel/types": "npm:^7.26.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 07e01683b02f12e36eba54a92e8e3db0b362bb6aa624eaf3e4ef54c190148de33004adbabd97961a56182c17b170f3c8835c5f2ff3e100c5a7dc2a8de57c8c88
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.24.7"
@@ -560,6 +809,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 3c23ef34e3fd7da3578428cb488180ab6b7b96c9c141438374b6d87fa814d87de099f28098e5fc64726c19193a1da397e4d2351d40b459bcd2489993557e2c74
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-safari-class-field-initializer-scope@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-bugfix-safari-class-field-initializer-scope@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: d3e14ab1cb9cb50246d20cab9539f2fbd1e7ef1ded73980c8ad7c0561b4d5e0b144d362225f0976d47898e04cbd40f2000e208b0913bd788346cf7791b96af91
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.24.7"
@@ -568,6 +840,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: f0e0e9bdcf5479f8c5b4494353dc64dee37205e5ffd30920e649e75537a8f795cdcf32dfb40a00e908469a5d61cf62806bc359294cb2a6f2e604bf4efe086301
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: a9d1ee3fd100d3eb6799a2f2bbd785296f356c531d75c9369f71541811fa324270258a374db103ce159156d006da2f33370330558d0133e6f7584152c34997ca
   languageName: node
   linkType: hard
 
@@ -584,6 +867,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.9"
+    "@babel/plugin-transform-optional-chaining": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.13.0
+  checksum: 5b298b28e156f64de51cdb03a2c5b80c7f978815ef1026f3ae8b9fc48d28bf0a83817d8fbecb61ef8fb94a7201f62cca5103cc6e7b9e8f28e38f766d7905b378
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:7.24.7"
@@ -593,6 +889,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: ad63317eb72ca7e160394e9223768b1f826287eaf65297f2794d0203510225f20dd9858bce217af4a050754abf94565841617b45b35a2de355c4e2bba546b39c
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: cb893e5deb9312a0120a399835b6614a016c036714de7123c8edabccc56a09c4455016e083c5c4dd485248546d4e5e55fc0e9132b3c3a9bd16abf534138fe3f2
   languageName: node
   linkType: hard
 
@@ -671,6 +979,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-import-assertions@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/plugin-syntax-import-assertions@npm:7.26.0"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b58f2306df4a690ca90b763d832ec05202c50af787158ff8b50cdf3354359710bce2e1eb2b5135fcabf284756ac8eadf09ca74764aa7e76d12a5cac5f6b21e67
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-import-attributes@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-syntax-import-attributes@npm:7.24.7"
@@ -679,6 +998,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 22fc50bd85a491bb8d22065f330a41f60d66f2f2d7a1deb73e80c8a4b5d7a42a092a03f8da18800650eca0fc14585167cc4e5c9fab351f0d390d1592347162ae
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-import-attributes@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/plugin-syntax-import-attributes@npm:7.26.0"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c122aa577166c80ee67f75aebebeef4150a132c4d3109d25d7fc058bf802946f883e330f20b78c1d3e3a5ada631c8780c263d2d01b5dbaecc69efefeedd42916
   languageName: node
   linkType: hard
 
@@ -712,6 +1042,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: a93516ae5b34868ab892a95315027d4e5e38e8bd1cfca6158f2974b0901cbb32bbe64ea10ad5b25f919ddc40c6d8113c4823372909c9c9922170c12b0b1acecb
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-syntax-jsx@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bb609d1ffb50b58f0c1bac8810d0e46a4f6c922aa171c458f3a19d66ee545d36e782d3bffbbc1fed0dc65a558bdce1caf5279316583c0fff5a2c1658982a8563
   languageName: node
   linkType: hard
 
@@ -814,6 +1155,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-syntax-typescript@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-syntax-typescript@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0e9821e8ba7d660c36c919654e4144a70546942ae184e85b8102f2322451eae102cbfadbcadd52ce077a2b44b400ee52394c616feab7b5b9f791b910e933fd33
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-syntax-unicode-sets-regex@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-unicode-sets-regex@npm:7.18.6"
@@ -837,6 +1189,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-arrow-functions@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-arrow-functions@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: c29f081224859483accf55fb4d091db2aac0dcd0d7954bac5ca889030cc498d3f771aa20eb2e9cd8310084ec394d85fa084b97faf09298b6bc9541182b3eb5bb
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-async-generator-functions@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-async-generator-functions@npm:7.24.7"
@@ -848,6 +1211,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: cf0a4b5ffc6d7f3f3bf12d4792535e8a46332714211326fd5058a6e45988891ee402b26cb9cc6c7121b2c8283ebd160e431827f885bdfa51d6127f934bd9ba7f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-async-generator-functions@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-async-generator-functions@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-remap-async-to-generator": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 99306c44a4a791abd51a56d89fa61c4cfe805a58e070c7fb1cbf950886778a6c8c4f25a92d231f91da1746d14a338436073fd83038e607f03a2a98ac5340406b
   languageName: node
   linkType: hard
 
@@ -864,6 +1240,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-async-to-generator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-async-to-generator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-remap-async-to-generator": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b3ad50fb93c171644d501864620ed23952a46648c4df10dc9c62cc9ad08031b66bd272cfdd708faeee07c23b6251b16f29ce0350473e4c79f0c32178d38ce3a6
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-block-scoped-functions@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.24.7"
@@ -875,6 +1264,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-block-scoped-functions@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-block-scoped-functions@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bf31896556b33a80f017af3d445ceb532ec0f5ca9d69bc211a963ac92514d172d5c24c5ac319f384d9dfa7f1a4d8dc23032c2fe3e74f98a59467ecd86f7033ae
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-block-scoping@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-block-scoping@npm:7.24.7"
@@ -883,6 +1283,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9656e7bb0673279e18d9f9408027786f1b20d657e2cc106456e0bd7826bd12d81813299adbef2b2a5837b05740f2295fe8fb62389122d38c9e961b3005270777
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-block-scoping@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-block-scoping@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 89dcdd7edb1e0c2f44e3c568a8ad8202e2574a8a8308248550a9391540bc3f5c9fbd8352c60ae90769d46f58d3ab36f2c3a0fbc1c3620813d92ff6fccdfa79c8
   languageName: node
   linkType: hard
 
@@ -898,6 +1309,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-class-properties@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-class-properties@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a8d69e2c285486b63f49193cbcf7a15e1d3a5f632c1c07d7a97f65306df7f554b30270b7378dde143f8b557d1f8f6336c643377943dec8ec405e4cd11e90b9ea
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-class-static-block@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-class-static-block@npm:7.24.7"
@@ -908,6 +1331,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.12.0
   checksum: 00b4d35788bcfefb56b6a1d3506ca23f11dd55d4bb5a34eb70397c06283dc7f596cd9d40995c4a6cb897b45ad220de211f854e7a030a05e26a307c8f56b6ba4b
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-class-static-block@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/plugin-transform-class-static-block@npm:7.26.0"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.12.0
+  checksum: 60cba3f125a7bc4f90706af0a011697c7ffd2eddfba336ed6f84c5f358c44c3161af18b0202475241a96dee7964d96dd3a342f46dbf85b75b38bb789326e1766
   languageName: node
   linkType: hard
 
@@ -929,6 +1364,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-classes@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-classes@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-compilation-targets": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-replace-supers": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+    globals: "npm:^11.1.0"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1914ebe152f35c667fba7bf17ce0d9d0f33df2fb4491990ce9bb1f9ec5ae8cbd11d95b0dc371f7a4cc5e7ce4cf89467c3e34857302911fc6bfb6494a77f7b37e
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-computed-properties@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-computed-properties@npm:7.24.7"
@@ -941,6 +1392,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-computed-properties@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-computed-properties@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/template": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: aa1a9064d6a9d3b569b8cae6972437315a38a8f6553ee618406da5122500a06c2f20b9fa93aeed04dd895923bf6f529c09fc79d4be987ec41785ceb7d2203122
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-destructuring@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-destructuring@npm:7.24.7"
@@ -949,6 +1412,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: eec43df24a07b3c61f335883e50c6642762fdd3cc5c5f95532cebeb51ea9bf77ca9a38011b678d91549dd75e29e1c58bd6e0ebc34bb763c300bc2cc65801e663
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-destructuring@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-destructuring@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 51b24fbead910ad0547463b2d214dd08076b22a66234b9f878b8bac117603dd23e05090ff86e9ffc373214de23d3e5bf1b095fe54cce2ca16b010264d90cf4f5
   languageName: node
   linkType: hard
 
@@ -964,6 +1438,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-dotall-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-dotall-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8bdf1bb9e6e3a2cc8154ae88a3872faa6dc346d6901994505fb43ac85f858728781f1219f40b67f7bb0687c507450236cb7838ac68d457e65637f98500aa161b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-duplicate-keys@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-duplicate-keys@npm:7.24.7"
@@ -972,6 +1458,29 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 4284d8fe058c838f80d594bace1380ce02995fa9a271decbece59c40815bc2f7e715807dcbe4d5da8b444716e6d05cc6d79771f500fb044cd0dd00ce4324b619
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-duplicate-keys@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-duplicate-keys@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10dbb87bc09582416f9f97ca6c40563655abf33e3fd0fee25eeaeff28e946a06651192112a2bc2b18c314a638fa15c55b8365a677ef67aa490848cefdc57e1d8
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-duplicate-named-capturing-groups-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-duplicate-named-capturing-groups-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: f7233cf596be8c6843d31951afaf2464a62a610cb89c72c818c044765827fab78403ab8a7d3a6386f838c8df574668e2a48f6c206b1d7da965aff9c6886cb8e6
   languageName: node
   linkType: hard
 
@@ -987,6 +1496,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-dynamic-import@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-dynamic-import@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: aaca1ccda819be9b2b85af47ba08ddd2210ff2dbea222f26e4cd33f97ab020884bf81a66197e50872721e9daf36ceb5659502c82199884ea74d5d75ecda5c58b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-exponentiation-operator@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.24.7"
@@ -996,6 +1516,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 014b211f73a524ee98441541ddc4f6b067eefcf94d509e99074a45ea8c3f3ad0e36cab6f5f96666ac05b747a21fa6fda949aa25153656bb2821545a4b302e0d4
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-exponentiation-operator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-exponentiation-operator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-builder-binary-assignment-operator-visitor": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 57e1bb4135dd16782fe84b49dd360cce8f9bf5f62eb10424dcdaf221e54a8bacdf50f2541c5ac01dea9f833a6c628613d71be915290938a93454389cba4de06b
   languageName: node
   linkType: hard
 
@@ -1011,6 +1543,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-export-namespace-from@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-export-namespace-from@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 4dfe8df86c5b1d085d591290874bb2d78a9063090d71567ed657a418010ad333c3f48af2c974b865f53bbb718987a065f89828d43279a7751db1a56c9229078d
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-for-of@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-for-of@npm:7.24.7"
@@ -1020,6 +1563,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: ea471ad1345f1153f7f72f1f084e74f48dc349272ca1b2d8710b841b015c9861d673e12c3c98d42ab3c640cb6ab88bb9a8da1f4ca9c57a8f71f00815fa23ecef
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-for-of@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-for-of@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 63a2db7fe06c2e3f5fc1926f478dac66a5f7b3eaeb4a0ffae577e6f3cb3d822cb1ed2ed3798f70f5cb1aa06bc2ad8bcd1f557342f5c425fd83c37a8fc1cfd2ba
   languageName: node
   linkType: hard
 
@@ -1036,6 +1591,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-function-name@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-function-name@npm:7.25.9"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a8d7c8d019a6eb57eab5ca1be3e3236f175557d55b1f3b11f8ad7999e3fbb1cf37905fd8cb3a349bffb4163a558e9f33b63f631597fdc97c858757deac1b2fd7
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-json-strings@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-json-strings@npm:7.24.7"
@@ -1048,6 +1616,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-json-strings@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-json-strings@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e2498d84761cfd05aaea53799933d55af309c9d6204e66b38778792d171e4d1311ad34f334259a3aa3407dd0446f6bd3e390a1fcb8ce2e42fe5aabed0e41bee1
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-literals@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-literals@npm:7.24.7"
@@ -1056,6 +1635,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: bf341a5a0ffb5129670ac9a14ea53b67bd1d3d0e13173ce7ac2d4184c4b405d33f67df68c59a2e94a895bf80269ec1df82c011d9ddb686f9f08a40c37b881177
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-literals@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-literals@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3cca75823a38aab599bc151b0fa4d816b5e1b62d6e49c156aa90436deb6e13649f5505973151a10418b64f3f9d1c3da53e38a186402e0ed7ad98e482e70c0c14
   languageName: node
   linkType: hard
 
@@ -1071,6 +1661,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-logical-assignment-operators@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-logical-assignment-operators@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8c6febb4ac53852314d28b5e2c23d5dbbff7bf1e57d61f9672e0d97531ef7778b3f0ad698dcf1179f5486e626c77127508916a65eb846a89e98a92f70ed3537b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-member-expression-literals@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-member-expression-literals@npm:7.24.7"
@@ -1079,6 +1680,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 837b60ea42fc69a430c8f7fb124247ba009ff6d93187a521fe9f83556fe124715bd46533b1684a3e139f272849a14d1d4faf3397bde13714f99ce0938526ea6f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-member-expression-literals@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-member-expression-literals@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: db92041ae87b8f59f98b50359e0bb172480f6ba22e5e76b13bdfe07122cbf0daa9cd8ad2e78dcb47939938fed88ad57ab5989346f64b3a16953fc73dea3a9b1f
   languageName: node
   linkType: hard
 
@@ -1094,6 +1706,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-modules-amd@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-modules-amd@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 75d34c6e709a23bcfa0e06f722c9a72b1d9ac3e7d72a07ef54a943d32f65f97cbbf0e387d874eb9d9b4c8d33045edfa8e8441d0f8794f3c2b9f1d71b928acf2c
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-modules-commonjs@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-modules-commonjs@npm:7.24.7"
@@ -1104,6 +1728,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9bd10cd03cce138a644f4e671025058348d8ff364253122bed60f9a2a32759445b93e8a6501773491cb19906602b18fd26255df0caac425343a1584599b36b24
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-commonjs@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-simple-access": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a7390ca999373ccdef91075f274d1ace3a5cb79f9b9118ed6f76e94867ed454cf798a6f312ce2c4cdc1e035a25d810d754e4cb2e4d866acb4219490f3585de60
   languageName: node
   linkType: hard
 
@@ -1121,6 +1758,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-modules-systemjs@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 03145aa89b7c867941a03755216cfb503df6d475a78df84849a157fa5f2fcc17ba114a968d0579ae34e7c61403f35d1ba5d188fdfb9ad05f19354eb7605792f9
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-modules-umd@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-modules-umd@npm:7.24.7"
@@ -1130,6 +1781,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: cef9c8917b3c35c3b6cb424dc2e6f74016122f1d25c196e2c7e51eb080d95e96c5d34966c0d5b9d4e17b8e60d455a97ed271317ed104e0e70bff159830a59678
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-modules-umd@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-modules-umd@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-transforms": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 47d03485fedac828832d9fee33b3b982a6db8197e8651ceb5d001890e276150b5a7ee3e9780749e1ba76453c471af907a159108832c24f93453dd45221788e97
   languageName: node
   linkType: hard
 
@@ -1145,6 +1808,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-named-capturing-groups-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-named-capturing-groups-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 434346ba05cf74e3f4704b3bdd439287b95cd2a8676afcdc607810b8c38b6f4798cd69c1419726b2e4c7204e62e4a04d31b0360e91ca57a930521c9211e07789
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-new-target@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-new-target@npm:7.24.7"
@@ -1153,6 +1828,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 91b6a7439b7622f80dc755ddfb9ab083355bedc0b2af18e7c7a948faed14467599609331c8d59cfab4273640e3fc36e4cd02ad5b6dcb4a428f5a8baefc507acc
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-new-target@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-new-target@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 07bb3a09028ee7b8e8ede6e6390e3b3aecc5cf9adb2fc5475ff58036c552b8a3f8e63d4c43211a60545f3307cdc15919f0e54cb5455d9546daed162dc54ff94e
   languageName: node
   linkType: hard
 
@@ -1168,6 +1854,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-nullish-coalescing-operator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-nullish-coalescing-operator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 26e03b1c2c0408cc300e46d8f8cb639653ff3a7b03456d0d8afbb53c44f33a89323f51d99991dade3a5676921119bbdf869728bb7911799b5ef99ffafa2cdd24
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-numeric-separator@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-numeric-separator@npm:7.24.7"
@@ -1177,6 +1874,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: dc5bb0534889d207b1da125635471c42da61a4a4e9e68855f24b1cd04ccdcf8325b2c29112e719913c2097242e7e62d660e0fea2a46f3a9a983c9d02a0ec7a04
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-numeric-separator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-numeric-separator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 0528ef041ed88e8c3f51624ee87b8182a7f246fe4013f0572788e0727d20795b558f2b82e3989b5dd416cbd339500f0d88857de41b6d3b6fdacb1d5344bcc5b1
   languageName: node
   linkType: hard
 
@@ -1194,6 +1902,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-object-rest-spread@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-object-rest-spread@npm:7.25.9"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/plugin-transform-parameters": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a157ac5af2721090150858f301d9c0a3a0efb8ef66b90fce326d6cc0ae45ab97b6219b3e441bf8d72a2287e95eb04dd6c12544da88ea2345e70b3fac2c0ac9e2
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-object-super@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-object-super@npm:7.24.7"
@@ -1206,6 +1927,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-object-super@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-object-super@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-replace-supers": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1817b5d8b80e451ae1ad9080cca884f4f16df75880a158947df76a2ed8ab404d567a7dce71dd8051ef95f90fbe3513154086a32aba55cc76027f6cbabfbd7f98
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-optional-catch-binding@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.24.7"
@@ -1215,6 +1948,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 605ae3764354e83f73c1e6430bac29e308806abcce8d1369cf69e4921771ff3592e8f60ba60c15990070d79b8d8740f0841069d64b466b3ce8a8c43e9743da7e
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-optional-catch-binding@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-optional-catch-binding@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: b46a8d1e91829f3db5c252583eb00d05a779b4660abeea5500fda0f8ffa3584fd18299443c22f7fddf0ed9dfdb73c782c43b445dc468d4f89803f2356963b406
   languageName: node
   linkType: hard
 
@@ -1231,6 +1975,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-optional-chaining@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-optional-chaining@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: bc838a499fd9892e163b8bc9bfbc4bf0b28cc3232ee0a6406ae078257c8096518f871d09b4a32c11f4a2d6953c3bc1984619ef748f7ad45aed0b0d9689a8eb36
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-parameters@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-parameters@npm:7.24.7"
@@ -1239,6 +1995,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 41ff6bda926fabfb2e5d90b70621f279330691bed92009297340a8e776cfe9c3f2dda6afbc31dd3cbdccdfa9a5c57f2046e3ccc84f963c3797356df003d1703a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-parameters@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-parameters@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 014009a1763deb41fe9f0dbca2c4489ce0ac83dd87395f488492e8eb52399f6c883d5bd591bae3b8836f2460c3937fcebd07e57dce1e0bfe30cdbc63fdfc9d3a
   languageName: node
   linkType: hard
 
@@ -1251,6 +2018,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 5338df2aae53c43e6a7ea0c44f20a1100709778769c7e42d4901a61945c3200ba0e7fca83832f48932423a68528219fbea233cb5b8741a2501fdecbacdc08292
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-private-methods@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-private-methods@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 6e3671b352c267847c53a170a1937210fa8151764d70d25005e711ef9b21969aaf422acc14f9f7fb86bc0e4ec43e7aefcc0ad9196ae02d262ec10f509f126a58
   languageName: node
   linkType: hard
 
@@ -1268,6 +2047,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-private-property-in-object@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-private-property-in-object@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-create-class-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: aa45bb5669b610afa763d774a4b5583bb60ce7d38e4fd2dedfd0703e73e25aa560e6c6124e155aa90b101601743b127d9e5d3eb00989a7e4b4ab9c2eb88475ba
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-property-literals@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-property-literals@npm:7.24.7"
@@ -1276,6 +2068,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 71708890fe007d45ad7a130150a2ba1fea0205f575b925ca2e1bb65018730636a68e65c634a474e5b658378d72871c337c953560009c081a645e088769bf168a
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-property-literals@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-property-literals@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 436046ab07d54a9b44a384eeffec701d4e959a37a7547dda72e069e751ca7ff753d1782a8339e354b97c78a868b49ea97bf41bf5a44c6d7a3c0a05ad40eeb49c
   languageName: node
   linkType: hard
 
@@ -1301,6 +2104,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-display-name@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-react-display-name@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: dc7affde0ed98e40f629ee92a2fc44fbd8008aabda1ddb3f5bd2632699d3289b08dff65b26cf3b89dab46397ec440f453d19856bbb3a9a83df5b4ac6157c5c39
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx-development@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-react-jsx-development@npm:7.22.5"
@@ -1309,6 +2123,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 36bc3ff0b96bb0ef4723070a50cfdf2e72cfd903a59eba448f9fe92fea47574d6f22efd99364413719e1f3fb3c51b6c9b2990b87af088f8486a84b2a5f9e4560
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-development@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-react-jsx-development@npm:7.25.9"
+  dependencies:
+    "@babel/plugin-transform-react-jsx": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 537d38369537f1eb56041c4b770bc0733fde1801a7f5ffef40a1217ea448f33ee2fa8e6098a58a82fd00e432c1b9426a66849496da419020c9eca3b1b1a23779
   languageName: node
   linkType: hard
 
@@ -1327,6 +2152,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-react-jsx@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-module-imports": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/plugin-syntax-jsx": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: eb179ecdf0ae19aed254105cf78fbac35f9983f51ed04b7b67c863a4820a70a879bd5da250ac518321f86df20eac010e53e3411c8750c386d51da30e4814bfb6
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-pure-annotations@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/plugin-transform-react-pure-annotations@npm:7.22.5"
@@ -1336,6 +2176,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 092021c4f404e267002099ec20b3f12dd730cb90b0d83c5feed3dc00dbe43b9c42c795a18e7c6c7d7bddea20c7dd56221b146aec81b37f2e7eb5137331c61120
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-pure-annotations@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-react-pure-annotations@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 9995c0fc7c25d3aaaa0ce84233de02eab2564ea111d0813ec5baa538eb21520402879cc787ad1ad4c2061b99cebc3beb09910e64c9592e8ccb42ae62d9e4fd9a
   languageName: node
   linkType: hard
 
@@ -1351,6 +2203,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-regenerator@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-regenerator@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    regenerator-transform: "npm:^0.15.2"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 1c09e8087b476c5967282c9790fb8710e065eda77c60f6cb5da541edd59ded9d003d96f8ef640928faab4a0b35bf997673499a194973da4f0c97f0935807a482
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-regexp-modifiers@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/plugin-transform-regexp-modifiers@npm:7.26.0"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 726deca486bbd4b176f8a966eb0f4aabc19d9def3b8dabb8b3a656778eca0df1fda3f3c92b213aa5a184232fdafd5b7bd73b4e24ca4345c498ef6baff2bda4e1
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-reserved-words@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-reserved-words@npm:7.24.7"
@@ -1362,19 +2238,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.22.9":
-  version: 7.23.2
-  resolution: "@babel/plugin-transform-runtime@npm:7.23.2"
+"@babel/plugin-transform-reserved-words@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-reserved-words@npm:7.25.9"
   dependencies:
-    "@babel/helper-module-imports": "npm:^7.22.15"
-    "@babel/helper-plugin-utils": "npm:^7.22.5"
-    babel-plugin-polyfill-corejs2: "npm:^0.4.6"
-    babel-plugin-polyfill-corejs3: "npm:^0.8.5"
-    babel-plugin-polyfill-regenerator: "npm:^0.5.3"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 8beda04481b25767acbd1f6b9ef7b3a9c12fbd9dcb24df45a6ad120e1dc4b247c073db60ac742f9093657d6d8c050501fc0606af042f81a3bb6a3ff862cddc47
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-runtime@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-runtime@npm:7.25.9"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    babel-plugin-polyfill-corejs2: "npm:^0.4.10"
+    babel-plugin-polyfill-corejs3: "npm:^0.10.6"
+    babel-plugin-polyfill-regenerator: "npm:^0.6.1"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 536c444c494a43c1de4eec8297242199a7e778a82f64a8203a15bec46af17757ad59b520ee1fb414a03100ae743b8a2ca8527b6c0e4cc3e05be9ac1361260a44
+  checksum: d8d4f04a47cfc1a6103ecee8604750ba2184cd947ee1696cdc363639f0d4a3848839e20f0ca63511af9ad6742f7dd813cca5b2640353f7b0816bbc17ff0e9e88
   languageName: node
   linkType: hard
 
@@ -1386,6 +2273,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: c68c2be965007e0cb6667daa209bc0af877cab4b327ef2e21b2114c38554243c3f7fdcc5b03679b20f72a26d966aa646af771f3165c882067e85a3887647f028
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-shorthand-properties@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-shorthand-properties@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f774995d58d4e3a992b732cf3a9b8823552d471040e280264dd15e0735433d51b468fef04d75853d061309389c66bda10ce1b298297ce83999220eb0ad62741d
   languageName: node
   linkType: hard
 
@@ -1401,6 +2299,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-spread@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-spread@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: fe72c6545267176cdc9b6f32f30f9ced37c1cafa1290e4436b83b8f377b4f1c175dad404228c96e3efdec75da692f15bfb9db2108fcd9ad260bc9968778ee41e
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-sticky-regex@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-sticky-regex@npm:7.24.7"
@@ -1409,6 +2319,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 3b9a99ae043ef363c81bfb097fa7a553fcf7c7d9fddc13dd2b47b3b2e45cf2741a9ca78cfe55f463983b043b365f0f8452f2d5eaadbdea20e6d6de50c16bed25
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-sticky-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-sticky-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 7454b00844dbe924030dd15e2b3615b36e196500c4c47e98dabc6b37a054c5b1038ecd437e910aabf0e43bf56b973cb148d3437d50f6e2332d8309568e3e979b
   languageName: node
   linkType: hard
 
@@ -1423,6 +2344,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-template-literals@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-template-literals@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 92eb1d6e2d95bd24abbb74fa7640d02b66ff6214e0bb616d7fda298a7821ce15132a4265d576a3502a347a3c9e94b6c69ed265bb0784664592fa076785a3d16a
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-typeof-symbol@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-typeof-symbol@npm:7.24.7"
@@ -1431,6 +2363,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: c07847a3bcb27509d392de7a59b9836669b90ca508d4b63b36bb73b63413bc0b2571a64410b65999a73abeac99957b31053225877dcbfaf4eb21d8cc0ae4002f
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-typeof-symbol@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-typeof-symbol@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3ae240358f0b0cd59f8610d6c59d395c216fd1bab407f7de58b86d592f030fb42b4d18e2456a29bee4a2ff014c4c1e3404c8ae64462b1155d1c053b2f9d73438
   languageName: node
   linkType: hard
 
@@ -1448,6 +2391,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-typescript@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-typescript@npm:7.25.9"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.25.9"
+    "@babel/helper-create-class-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.25.9"
+    "@babel/plugin-syntax-typescript": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 91e2ec805f89a813e0bf9cf42dffb767f798429e983af3e2f919885a2826b10f29223dd8b40ccc569eb61858d3273620e82e14431603a893e4a7f9b4c1a3a3cf
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-unicode-escapes@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-unicode-escapes@npm:7.24.7"
@@ -1456,6 +2414,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 6b8bca3495acedc89e880942de7b83c263fb5b4c9599594dcf3923e2128ae25f1f4725a295fe101027f75d8ef081ef28319296adf274b5022e57039e42836103
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-escapes@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-unicode-escapes@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: f138cbee539963fb3da13f684e6f33c9f7495220369ae12a682b358f1e25ac68936825562c38eae87f01ac9992b2129208b35ec18533567fc805ce5ed0ffd775
   languageName: node
   linkType: hard
 
@@ -1471,6 +2440,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-unicode-property-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-unicode-property-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 201f6f46c1beb399e79aa208b94c5d54412047511795ce1e790edcd189cef73752e6a099fdfc01b3ad12205f139ae344143b62f21f44bbe02338a95e8506a911
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-unicode-regex@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/plugin-transform-unicode-regex@npm:7.24.7"
@@ -1480,6 +2461,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: b545310d0d592d75566b9cd158f4b8951e34d07d839656789d179b39b3fd92b32bd387cdfaf33a93e636609f3bfb9bb03d41f3e43be598116c9c6c80cc3418c4
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-unicode-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-unicode-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: e8baae867526e179467c6ef5280d70390fa7388f8763a19a27c21302dd59b121032568be080749514b097097ceb9af716bf4b90638f1b3cf689aa837ba20150f
   languageName: node
   linkType: hard
 
@@ -1495,7 +2488,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:^7.20.2, @babel/preset-env@npm:^7.22.9":
+"@babel/plugin-transform-unicode-sets-regex@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/plugin-transform-unicode-sets-regex@npm:7.25.9"
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 4445ef20de687cb4dcc95169742a8d9013d680aa5eee9186d8e25875bbfa7ee5e2de26a91177ccf70b1db518e36886abcd44750d28db5d7a9539f0efa6839f4b
+  languageName: node
+  linkType: hard
+
+"@babel/preset-env@npm:^7.20.2":
   version: 7.24.7
   resolution: "@babel/preset-env@npm:7.24.7"
   dependencies:
@@ -1586,6 +2591,85 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-env@npm:^7.25.9":
+  version: 7.26.0
+  resolution: "@babel/preset-env@npm:7.26.0"
+  dependencies:
+    "@babel/compat-data": "npm:^7.26.0"
+    "@babel/helper-compilation-targets": "npm:^7.25.9"
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-validator-option": "npm:^7.25.9"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.25.9"
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope": "npm:^7.25.9"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.25.9"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.25.9"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "npm:^7.25.9"
+    "@babel/plugin-proposal-private-property-in-object": "npm:7.21.0-placeholder-for-preset-env.2"
+    "@babel/plugin-syntax-import-assertions": "npm:^7.26.0"
+    "@babel/plugin-syntax-import-attributes": "npm:^7.26.0"
+    "@babel/plugin-syntax-unicode-sets-regex": "npm:^7.18.6"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.25.9"
+    "@babel/plugin-transform-async-generator-functions": "npm:^7.25.9"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.25.9"
+    "@babel/plugin-transform-block-scoped-functions": "npm:^7.25.9"
+    "@babel/plugin-transform-block-scoping": "npm:^7.25.9"
+    "@babel/plugin-transform-class-properties": "npm:^7.25.9"
+    "@babel/plugin-transform-class-static-block": "npm:^7.26.0"
+    "@babel/plugin-transform-classes": "npm:^7.25.9"
+    "@babel/plugin-transform-computed-properties": "npm:^7.25.9"
+    "@babel/plugin-transform-destructuring": "npm:^7.25.9"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.25.9"
+    "@babel/plugin-transform-duplicate-keys": "npm:^7.25.9"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "npm:^7.25.9"
+    "@babel/plugin-transform-dynamic-import": "npm:^7.25.9"
+    "@babel/plugin-transform-exponentiation-operator": "npm:^7.25.9"
+    "@babel/plugin-transform-export-namespace-from": "npm:^7.25.9"
+    "@babel/plugin-transform-for-of": "npm:^7.25.9"
+    "@babel/plugin-transform-function-name": "npm:^7.25.9"
+    "@babel/plugin-transform-json-strings": "npm:^7.25.9"
+    "@babel/plugin-transform-literals": "npm:^7.25.9"
+    "@babel/plugin-transform-logical-assignment-operators": "npm:^7.25.9"
+    "@babel/plugin-transform-member-expression-literals": "npm:^7.25.9"
+    "@babel/plugin-transform-modules-amd": "npm:^7.25.9"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.25.9"
+    "@babel/plugin-transform-modules-systemjs": "npm:^7.25.9"
+    "@babel/plugin-transform-modules-umd": "npm:^7.25.9"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.25.9"
+    "@babel/plugin-transform-new-target": "npm:^7.25.9"
+    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.25.9"
+    "@babel/plugin-transform-numeric-separator": "npm:^7.25.9"
+    "@babel/plugin-transform-object-rest-spread": "npm:^7.25.9"
+    "@babel/plugin-transform-object-super": "npm:^7.25.9"
+    "@babel/plugin-transform-optional-catch-binding": "npm:^7.25.9"
+    "@babel/plugin-transform-optional-chaining": "npm:^7.25.9"
+    "@babel/plugin-transform-parameters": "npm:^7.25.9"
+    "@babel/plugin-transform-private-methods": "npm:^7.25.9"
+    "@babel/plugin-transform-private-property-in-object": "npm:^7.25.9"
+    "@babel/plugin-transform-property-literals": "npm:^7.25.9"
+    "@babel/plugin-transform-regenerator": "npm:^7.25.9"
+    "@babel/plugin-transform-regexp-modifiers": "npm:^7.26.0"
+    "@babel/plugin-transform-reserved-words": "npm:^7.25.9"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.25.9"
+    "@babel/plugin-transform-spread": "npm:^7.25.9"
+    "@babel/plugin-transform-sticky-regex": "npm:^7.25.9"
+    "@babel/plugin-transform-template-literals": "npm:^7.25.9"
+    "@babel/plugin-transform-typeof-symbol": "npm:^7.25.9"
+    "@babel/plugin-transform-unicode-escapes": "npm:^7.25.9"
+    "@babel/plugin-transform-unicode-property-regex": "npm:^7.25.9"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.25.9"
+    "@babel/plugin-transform-unicode-sets-regex": "npm:^7.25.9"
+    "@babel/preset-modules": "npm:0.1.6-no-external-plugins"
+    babel-plugin-polyfill-corejs2: "npm:^0.4.10"
+    babel-plugin-polyfill-corejs3: "npm:^0.10.6"
+    babel-plugin-polyfill-regenerator: "npm:^0.6.1"
+    core-js-compat: "npm:^3.38.1"
+    semver: "npm:^6.3.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: a7a80314f845deea713985a6316361c476621c76cfe5c6c28e8b9558f01634b49bbfdd3581ef94b5d6cff5c2b8830468aa53a73f5b5c1224db2dfea5db7e676f
+  languageName: node
+  linkType: hard
+
 "@babel/preset-modules@npm:0.1.6-no-external-plugins":
   version: 0.1.6-no-external-plugins
   resolution: "@babel/preset-modules@npm:0.1.6-no-external-plugins"
@@ -1599,7 +2683,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-react@npm:^7.18.6, @babel/preset-react@npm:^7.22.5":
+"@babel/preset-react@npm:^7.18.6":
   version: 7.22.15
   resolution: "@babel/preset-react@npm:7.22.15"
   dependencies:
@@ -1615,7 +2699,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.21.0, @babel/preset-typescript@npm:^7.22.5":
+"@babel/preset-react@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/preset-react@npm:7.25.9"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-validator-option": "npm:^7.25.9"
+    "@babel/plugin-transform-react-display-name": "npm:^7.25.9"
+    "@babel/plugin-transform-react-jsx": "npm:^7.25.9"
+    "@babel/plugin-transform-react-jsx-development": "npm:^7.25.9"
+    "@babel/plugin-transform-react-pure-annotations": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3c9daf47cf51568d96984d21b9f83992590c0e91f16a333f999100bb3c2c200730cde6806ed37fd2c999e0a63becefc881740b8f765b5a4aff4efc674e3e4197
+  languageName: node
+  linkType: hard
+
+"@babel/preset-typescript@npm:^7.21.0":
   version: 7.24.7
   resolution: "@babel/preset-typescript@npm:7.24.7"
   dependencies:
@@ -1630,6 +2730,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-typescript@npm:^7.25.9":
+  version: 7.26.0
+  resolution: "@babel/preset-typescript@npm:7.26.0"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.25.9"
+    "@babel/helper-validator-option": "npm:^7.25.9"
+    "@babel/plugin-syntax-jsx": "npm:^7.25.9"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.25.9"
+    "@babel/plugin-transform-typescript": "npm:^7.25.9"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 81a60826160163a3daae017709f42147744757b725b50c9024ef3ee5a402ee45fd2e93eaecdaaa22c81be91f7940916249cfb7711366431cfcacc69c95878c03
+  languageName: node
+  linkType: hard
+
 "@babel/regjsgen@npm:^0.8.0":
   version: 0.8.0
   resolution: "@babel/regjsgen@npm:0.8.0"
@@ -1637,22 +2752,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime-corejs3@npm:^7.22.6":
-  version: 7.23.2
-  resolution: "@babel/runtime-corejs3@npm:7.23.2"
+"@babel/runtime-corejs3@npm:^7.25.9":
+  version: 7.26.0
+  resolution: "@babel/runtime-corejs3@npm:7.26.0"
   dependencies:
     core-js-pure: "npm:^3.30.2"
     regenerator-runtime: "npm:^0.14.0"
-  checksum: ea48e6e4eaee6ec66f767f50d1ca6caeafee09521b6814c6ce45d57d630e14d1171dfbb596957f0d19049c500b87c81486048a31b7670c82f9208a8c417988bb
+  checksum: fd813d8b5bfc412c083033638c937e13f621b3223161c4a20bb8532d77ae622b620915476bd265670f6a8fc1a76a017ffd738ad25ad24431953e3725247c6520
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.6, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.3, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4":
   version: 7.23.2
   resolution: "@babel/runtime@npm:7.23.2"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
   checksum: abdcbdd590c7e31762e1bdab94dd466823c8bcedd3ff2fde85eeb94dac7cccaef151ac37c428bda7018ededd27c9a82b4dfeb621f978ad934232475a902f8e3a
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.25.9":
+  version: 7.26.0
+  resolution: "@babel/runtime@npm:7.26.0"
+  dependencies:
+    regenerator-runtime: "npm:^0.14.0"
+  checksum: 9f4ea1c1d566c497c052d505587554e782e021e6ccd302c2ad7ae8291c8e16e3f19d4a7726fb64469e057779ea2081c28b7dbefec6d813a22f08a35712c0f699
   languageName: node
   linkType: hard
 
@@ -1667,7 +2791,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.22.8, @babel/traverse@npm:^7.24.7":
+"@babel/template@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/template@npm:7.25.9"
+  dependencies:
+    "@babel/code-frame": "npm:^7.25.9"
+    "@babel/parser": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+  checksum: e861180881507210150c1335ad94aff80fd9e9be6202e1efa752059c93224e2d5310186ddcdd4c0f0b0fc658ce48cb47823f15142b5c00c8456dde54f5de80b2
+  languageName: node
+  linkType: hard
+
+"@babel/traverse@npm:^7.24.7":
   version: 7.24.7
   resolution: "@babel/traverse@npm:7.24.7"
   dependencies:
@@ -1685,6 +2820,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.25.9":
+  version: 7.25.9
+  resolution: "@babel/traverse@npm:7.25.9"
+  dependencies:
+    "@babel/code-frame": "npm:^7.25.9"
+    "@babel/generator": "npm:^7.25.9"
+    "@babel/parser": "npm:^7.25.9"
+    "@babel/template": "npm:^7.25.9"
+    "@babel/types": "npm:^7.25.9"
+    debug: "npm:^4.3.1"
+    globals: "npm:^11.1.0"
+  checksum: 7431614d76d4a053e429208db82f2846a415833f3d9eb2e11ef72eeb3c64dfd71f4a4d983de1a4a047b36165a1f5a64de8ca2a417534cc472005c740ffcb9c6a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.21.3, @babel/types@npm:^7.22.15, @babel/types@npm:^7.24.7, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.24.7
   resolution: "@babel/types@npm:7.24.7"
@@ -1693,6 +2843,16 @@ __metadata:
     "@babel/helper-validator-identifier": "npm:^7.24.7"
     to-fast-properties: "npm:^2.0.0"
   checksum: ad3c8c0d6fb4acb0bb74bb5b4bb849b181bf6185677ef9c59c18856c81e43628d0858253cf232f0eca806f02e08eff85a1d3e636a3e94daea737597796b0b430
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0":
+  version: 7.26.0
+  resolution: "@babel/types@npm:7.26.0"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.25.9"
+    "@babel/helper-validator-identifier": "npm:^7.25.9"
+  checksum: 40780741ecec886ed9edae234b5eb4976968cc70d72b4e5a40d55f83ff2cc457de20f9b0f4fe9d858350e43dab0ea496e7ef62e2b2f08df699481a76df02cd6e
   languageName: node
   linkType: hard
 
@@ -2029,57 +3189,96 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.4.0, @docusaurus/core@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/core@npm:3.4.0"
+"@docusaurus/babel@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/babel@npm:3.5.2-canary-6122"
   dependencies:
-    "@babel/core": "npm:^7.23.3"
-    "@babel/generator": "npm:^7.23.3"
+    "@babel/core": "npm:^7.25.9"
+    "@babel/generator": "npm:^7.25.9"
     "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
-    "@babel/plugin-transform-runtime": "npm:^7.22.9"
-    "@babel/preset-env": "npm:^7.22.9"
-    "@babel/preset-react": "npm:^7.22.5"
-    "@babel/preset-typescript": "npm:^7.22.5"
-    "@babel/runtime": "npm:^7.22.6"
-    "@babel/runtime-corejs3": "npm:^7.22.6"
-    "@babel/traverse": "npm:^7.22.8"
-    "@docusaurus/cssnano-preset": "npm:3.4.0"
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/mdx-loader": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
-    autoprefixer: "npm:^10.4.14"
-    babel-loader: "npm:^9.1.3"
+    "@babel/plugin-transform-runtime": "npm:^7.25.9"
+    "@babel/preset-env": "npm:^7.25.9"
+    "@babel/preset-react": "npm:^7.25.9"
+    "@babel/preset-typescript": "npm:^7.25.9"
+    "@babel/runtime": "npm:^7.25.9"
+    "@babel/runtime-corejs3": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
     babel-plugin-dynamic-import-node: "npm:^2.3.3"
-    boxen: "npm:^6.2.1"
-    chalk: "npm:^4.1.2"
-    chokidar: "npm:^3.5.3"
+    fs-extra: "npm:^11.1.1"
+    tslib: "npm:^2.6.0"
+  checksum: 2e4acb9132e8fbcd7b97afc315baee6f75a3c8228348c5216abf007a604798a82f12ffdc00e987ab92786e85d14f462274d8296480b0cc8e694609f050c9c5a1
+  languageName: node
+  linkType: hard
+
+"@docusaurus/bundler@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/bundler@npm:3.5.2-canary-6122"
+  dependencies:
+    "@babel/core": "npm:^7.25.9"
+    "@docusaurus/babel": "npm:3.5.2-canary-6122"
+    "@docusaurus/cssnano-preset": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    autoprefixer: "npm:^10.4.14"
+    babel-loader: "npm:^9.2.1"
     clean-css: "npm:^5.3.2"
-    cli-table3: "npm:^0.6.3"
-    combine-promises: "npm:^1.1.0"
-    commander: "npm:^5.1.0"
     copy-webpack-plugin: "npm:^11.0.0"
-    core-js: "npm:^3.31.1"
     css-loader: "npm:^6.8.1"
     css-minimizer-webpack-plugin: "npm:^5.0.1"
     cssnano: "npm:^6.1.2"
+    file-loader: "npm:^6.2.0"
+    html-minifier-terser: "npm:^7.2.0"
+    mini-css-extract-plugin: "npm:^2.9.1"
+    null-loader: "npm:^4.0.1"
+    postcss: "npm:^8.4.26"
+    postcss-loader: "npm:^7.3.3"
+    react-dev-utils: "npm:^12.0.1"
+    terser-webpack-plugin: "npm:^5.3.9"
+    tslib: "npm:^2.6.0"
+    url-loader: "npm:^4.1.1"
+    webpack: "npm:^5.95.0"
+    webpackbar: "npm:^6.0.1"
+  peerDependencies:
+    "@docusaurus/faster": 3.5.2
+  peerDependenciesMeta:
+    "@docusaurus/faster":
+      optional: true
+  checksum: 8e089c79304330b5f6730f6af7317e7083ef6df29b40b4896c3e1c531b355addf0bc70adea35a69ffc1ddc5f3bd10f64594f887606712e54f2be161f57695077
+  languageName: node
+  linkType: hard
+
+"@docusaurus/core@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/core@npm:3.5.2-canary-6122"
+  dependencies:
+    "@docusaurus/babel": "npm:3.5.2-canary-6122"
+    "@docusaurus/bundler": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    boxen: "npm:^6.2.1"
+    chalk: "npm:^4.1.2"
+    chokidar: "npm:^3.5.3"
+    cli-table3: "npm:^0.6.3"
+    combine-promises: "npm:^1.1.0"
+    commander: "npm:^5.1.0"
+    core-js: "npm:^3.31.1"
     del: "npm:^6.1.1"
     detect-port: "npm:^1.5.1"
     escape-html: "npm:^1.0.3"
     eta: "npm:^2.2.0"
     eval: "npm:^0.1.8"
-    file-loader: "npm:^6.2.0"
     fs-extra: "npm:^11.1.1"
-    html-minifier-terser: "npm:^7.2.0"
     html-tags: "npm:^3.3.1"
-    html-webpack-plugin: "npm:^5.5.3"
+    html-webpack-plugin: "npm:^5.6.0"
     leven: "npm:^3.1.0"
     lodash: "npm:^4.17.21"
-    mini-css-extract-plugin: "npm:^2.7.6"
     p-map: "npm:^4.0.0"
-    postcss: "npm:^8.4.26"
-    postcss-loader: "npm:^7.3.3"
     prompts: "npm:^2.4.2"
     react-dev-utils: "npm:^12.0.1"
     react-helmet-async: "npm:^1.3.0"
@@ -2090,55 +3289,70 @@ __metadata:
     react-router-dom: "npm:^5.3.4"
     rtl-detect: "npm:^1.0.4"
     semver: "npm:^7.5.4"
-    serve-handler: "npm:^6.1.5"
+    serve-handler: "npm:^6.1.6"
     shelljs: "npm:^0.8.5"
-    terser-webpack-plugin: "npm:^5.3.9"
     tslib: "npm:^2.6.0"
     update-notifier: "npm:^6.0.2"
-    url-loader: "npm:^4.1.1"
-    webpack: "npm:^5.88.1"
-    webpack-bundle-analyzer: "npm:^4.9.0"
-    webpack-dev-server: "npm:^4.15.1"
-    webpack-merge: "npm:^5.9.0"
-    webpackbar: "npm:^5.0.2"
+    webpack: "npm:^5.95.0"
+    webpack-bundle-analyzer: "npm:^4.10.2"
+    webpack-dev-server: "npm:^4.15.2"
+    webpack-merge: "npm:^6.0.1"
   peerDependencies:
+    "@mdx-js/react": ^3.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
   bin:
     docusaurus: bin/docusaurus.mjs
-  checksum: 2acaeadfe96b266088542ac74f7f8bdbab550e5abee2d2ef14e05d92a60d89b4312a4bf69dd9cbe3808bb5f3defc56c4e5c126b0797d31bc9919b79db21c1997
+  checksum: b778e9de54f2a2045c13a59c2211498d018240271a74e0e8918b296875f9db274cce20dbe1339d5cae6a00e29ffd1b60e279d1432ae5c31879fbaa99fb7dbb10
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/cssnano-preset@npm:3.4.0"
+"@docusaurus/cssnano-preset@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/cssnano-preset@npm:3.5.2-canary-6122"
   dependencies:
     cssnano-preset-advanced: "npm:^6.1.2"
     postcss: "npm:^8.4.38"
     postcss-sort-media-queries: "npm:^5.2.0"
     tslib: "npm:^2.6.0"
-  checksum: cc1892257cd49d752df615f6194b32ce810cdbf71b4fd32aa268cbd4b41071991d5573fca77417cc1f4cc1f85a9097d8cbc6d8eb413292a5d38b8d062e39489a
+  checksum: 8c22fa55aa8d4de56b0d5b5dbfd3b321728a178e36719384650bad6fd5975a20b285ce888479d83e6e82d7beb5c674981b5ecab0f5fbf307e27e9153c55df9e5
   languageName: node
   linkType: hard
 
-"@docusaurus/logger@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/logger@npm:3.4.0"
+"@docusaurus/faster@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/faster@npm:3.5.2-canary-6122"
+  dependencies:
+    "@rspack/core": "npm:^1.0.14"
+    "@swc/core": "npm:^1.7.39"
+    "@swc/html": "npm:^1.7.39"
+    browserslist: "npm:^4.24.2"
+    lightningcss: "npm:^1.27.0"
+    swc-loader: "npm:^0.2.6"
+    webpack: "npm:^5.95.0"
+  peerDependencies:
+    "@docusaurus/types": "*"
+  checksum: 713b0aa617ceccfe95e847e800bee9ea1ad0d66d5267b849c39a13a717c7bdba8922bb6cc600ed07a9574c4a24bed87346d859e9eb52b321f632f19098f66c31
+  languageName: node
+  linkType: hard
+
+"@docusaurus/logger@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/logger@npm:3.5.2-canary-6122"
   dependencies:
     chalk: "npm:^4.1.2"
     tslib: "npm:^2.6.0"
-  checksum: 0a58a7feed5651fa9e43c15d83232ddd2110c670d566a4cec910bfa90b0de5b986e5d20ed42f44e7324fc0cfa7244f774b45c9f35a9d81d7c321443d2ff2c3b9
+  checksum: 0f3d84780ad5cd9b80bf36b2328f07eedd8ff592dd341151124616497fbf09495cb98418058f129e4e68b01f403b4c897f25f485be5add2feb22ee5e40841155
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/mdx-loader@npm:3.4.0"
+"@docusaurus/mdx-loader@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/mdx-loader@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     "@mdx-js/mdx": "npm:^3.0.0"
     "@slorber/remark-comment": "npm:^1.0.0"
     escape-html: "npm:^1.0.3"
@@ -2163,15 +3377,15 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: aebfbd432ee8bcadff0ff15d33aebefb61fc2f4a8040ffb12f0e7200b5fc490ba063643d5188209722aa8c7b15fd9f1d9a70039c005f135efba174a39110b830
+  checksum: 8bf6f0b1c7f8fac9b798e8a4040062ca7b8a539058e7b5cd9370b149369b832d97354dec661fe59f5856e4270722b785adb83ec74356d86ac9e187345c0a7173
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:3.4.0, @docusaurus/module-type-aliases@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/module-type-aliases@npm:3.4.0"
+"@docusaurus/module-type-aliases@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/module-type-aliases@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/types": "npm:3.4.0"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
     "@types/react-router-config": "npm:*"
@@ -2181,22 +3395,23 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 581ca7ad71d9a3fb379427589dd4be541788bc7065b3effe623c831e5280b247e33b1568aff8400e3403797e0a6d797dff6000d9446571efe8917418caf00151
+  checksum: a620a8465437bd9f7bd0f0b3fd1ed9025cb62f7edc8b2bbd70adb35254e76b4d11cb456231aac1c2da7a17eb27ccc11d7241c67b610f48622c9c3fc265e9f49a
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-content-blog@npm:3.4.0"
+"@docusaurus/plugin-content-blog@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-content-blog@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/mdx-loader": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
-    cheerio: "npm:^1.0.0-rc.12"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    cheerio: "npm:1.0.0-rc.12"
     feed: "npm:^4.2.2"
     fs-extra: "npm:^11.1.1"
     lodash: "npm:^4.17.21"
@@ -2207,24 +3422,26 @@ __metadata:
     utility-types: "npm:^3.10.0"
     webpack: "npm:^5.88.1"
   peerDependencies:
+    "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 27bc3b6fc4d20667014d2efd8a6c69ac8ec55739807be39830e055a03334bae490f22caa891b700003446ddfa6cc1460d244eeb016d9cf5c5da78eeb253d0f90
+  checksum: 8f7634a09cd5a1aca3870cd9ee5e3ee7c89e76e3f9820dae04ca05cad847eabdfb1b690eb6e2d26871f5eda864c593ea125963cea1bef9f0224c4bcdd8e52ce2
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-content-docs@npm:3.4.0"
+"@docusaurus/plugin-content-docs@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/mdx-loader": "npm:3.4.0"
-    "@docusaurus/module-type-aliases": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     "@types/react-router-config": "npm:^5.0.7"
     combine-promises: "npm:^1.1.0"
     fs-extra: "npm:^11.1.1"
@@ -2236,156 +3453,157 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 46533013761bec354866a8ce4cd272fd3bfbbab2c68ae6a3e6e561d2f1eac99addc19993e88997508479025ef5d79fa711729822f805a34f1592d1299f343174
+  checksum: 3e8ccc94b3de16ac02fd8f84eeb4e3dd360a51086f01e9cacf566104f4d969627ba84755d36323da40093f8402cd91067e14f61ec5237967496fa8b7e4e8b136
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-content-pages@npm:3.4.0"
+"@docusaurus/plugin-content-pages@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/mdx-loader": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
     webpack: "npm:^5.88.1"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 6fbea942a147836af2320f47e1e5753cb7129fdab211055f35d95e43eb2be60c19bc01657f41da1641028ce708550c3c7698510df50ae79812fa053de111a8c3
+  checksum: 1e83c933dcde860cfc05cc711d43ea2e172ac2c99b5bce7c6aa592b3481125c9f6a61e70f64f46c308ba8079e7b6273037760f74e2487e5916d675fd75919549
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-debug@npm:3.4.0"
+"@docusaurus/plugin-debug@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-debug@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
     fs-extra: "npm:^11.1.1"
     react-json-view-lite: "npm:^1.2.0"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: f07caeed0608a62c447b1a495e48fa8fcc8248d9c385887e2e814bb7610ff09b4ab2d7b10ba8ecc5024880a4e37d958fcd99aa4684406a946d92121ab94149c1
+  checksum: d3c26f25f117e145f6dc0d6ee981d8f6e044a80254b5dd7b0d9b8154ea3936147e0e47358c219d2bf5795784e752aeb10d0a634eaa98e557b84362608a388207
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-google-analytics@npm:3.4.0"
+"@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: ade51012397c12dbe7d0563ad7b2e345e3acbbd7729bf490b6d0f0cc2527b91abdd41b31392786c4697591d5b1f066f9ad257f483deaa2f2ea5194e33e3cd821
+  checksum: 94d03d46caaa2927f334bc5ca0d60b6e9cfe4d27796b98c33abe219ab360d374ffd01e2c1853125ef5a799a463459c0bcc1e25296f158db83e6c401e5a02af5c
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-google-gtag@npm:3.4.0"
+"@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     "@types/gtag.js": "npm:^0.0.12"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: bab50eecf16d41b3a6896f0f222477495be63a195d012725042df6ea43a25281ca6929422b3b1ca901ae4127cf2000c05432afd01c69430fe973dc5a9ad35b9d
+  checksum: 56cc61410d6e61cf5198fa5f3c6638a95891aabce2318a1cc355f2c67156d09686bafaa9aef6be6703f8e229825ff92d0d8d27e4f6d42902107a11d55d9d9613
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-tag-manager@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.4.0"
+"@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 0b3e98856b81d66ba756fb2504bf54dbe24372fca0b4c298b6e83339be7c7c970c759bce3a4321b73c117d5eeef962f3395651100832bb3618f6cdb87f133b15
+  checksum: 1e41d1e7d07eececede6377d0cb4ff2003e57df84a9a5f99aa07d3abad02ead0dd9f03fb5a5397539c88b78892023e055b88e16475febc9ba5d835c6c4024a85
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/plugin-sitemap@npm:3.4.0"
+"@docusaurus/plugin-sitemap@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/plugin-sitemap@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     fs-extra: "npm:^11.1.1"
     sitemap: "npm:^7.1.1"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 23f4821d88f167ebcd9001e721b32c8c43fc049086aac10eaf3c0a79c992a6787de4533b1526ad060cc55d1eecd60c593e2b7e7457850b862be93108e3cdb97c
+  checksum: 20a4ab4c1e997dba108bc4053e0866f9f526700d5a55280f880a095697f6ef04a1c37bcfb8a3da1be49ccf6f13b04a10caaf779fed6b430f2184de0c1b19bfb7
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/preset-classic@npm:3.4.0"
+"@docusaurus/preset-classic@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/preset-classic@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/plugin-content-blog": "npm:3.4.0"
-    "@docusaurus/plugin-content-docs": "npm:3.4.0"
-    "@docusaurus/plugin-content-pages": "npm:3.4.0"
-    "@docusaurus/plugin-debug": "npm:3.4.0"
-    "@docusaurus/plugin-google-analytics": "npm:3.4.0"
-    "@docusaurus/plugin-google-gtag": "npm:3.4.0"
-    "@docusaurus/plugin-google-tag-manager": "npm:3.4.0"
-    "@docusaurus/plugin-sitemap": "npm:3.4.0"
-    "@docusaurus/theme-classic": "npm:3.4.0"
-    "@docusaurus/theme-common": "npm:3.4.0"
-    "@docusaurus/theme-search-algolia": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-debug": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-google-analytics": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-google-gtag": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-google-tag-manager": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-sitemap": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-classic": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-search-algolia": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 968833af162303685bebce71baed4ae662ce4c67957ceba0c9d697459c5e7996455a8a7ecb1b5c1a5978b475d5aa71605f8ec6b5b90459940310ffb2f4f5b6f1
+  checksum: 6d002daffb30497334d4209ca18d49c56c8ade6b047d4b78f061e3357adf244bd4b02d1a6f021e5b414cc8889eafc5b8f3255da0baece55f5dd122be64be9848
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:3.4.0, @docusaurus/theme-classic@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/theme-classic@npm:3.4.0"
+"@docusaurus/theme-classic@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/theme-classic@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/mdx-loader": "npm:3.4.0"
-    "@docusaurus/module-type-aliases": "npm:3.4.0"
-    "@docusaurus/plugin-content-blog": "npm:3.4.0"
-    "@docusaurus/plugin-content-docs": "npm:3.4.0"
-    "@docusaurus/plugin-content-pages": "npm:3.4.0"
-    "@docusaurus/theme-common": "npm:3.4.0"
-    "@docusaurus/theme-translations": "npm:3.4.0"
-    "@docusaurus/types": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-translations": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     "@mdx-js/react": "npm:^3.0.0"
     clsx: "npm:^2.0.0"
     copy-text-to-clipboard: "npm:^3.2.0"
-    infima: "npm:0.2.0-alpha.43"
+    infima: "npm:0.2.0-alpha.45"
     lodash: "npm:^4.17.21"
     nprogress: "npm:^0.2.0"
     postcss: "npm:^8.4.26"
@@ -2398,21 +3616,18 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 5c9e63797caa8123a8baf3f68b44ad03dab3f2c17c272c89e70fd8cd67be80c9bc979dff9ca7084fe47420ff6736b49da5b56a9ca5a6fb442f3df765b5af923c
+  checksum: dea6b7a74fbded73a98f524501da677b103445327b8ef6b5fc8dfa1af13ea85d23fe1d174139acc9877e063d4baa93250c05ad0f4df8e986c87fffa6c75e209b
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.4.0, @docusaurus/theme-common@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/theme-common@npm:3.4.0"
+"@docusaurus/theme-common@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/theme-common@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/mdx-loader": "npm:3.4.0"
-    "@docusaurus/module-type-aliases": "npm:3.4.0"
-    "@docusaurus/plugin-content-blog": "npm:3.4.0"
-    "@docusaurus/plugin-content-docs": "npm:3.4.0"
-    "@docusaurus/plugin-content-pages": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
     "@types/react-router-config": "npm:*"
@@ -2422,24 +3637,25 @@ __metadata:
     tslib: "npm:^2.6.0"
     utility-types: "npm:^3.10.0"
   peerDependencies:
+    "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 6a815feb6ae8ee5fb76ed76b10f826d8aa864926a31607ff7bff39ad5e1d95b215eec05acd66b9db667a8575c0283d90a373c52bb4d7262b02b69dd76932a534
+  checksum: 325aff256705c3f9ed2fe20d67b34315eb16fe2a6944a2cf732007427fb0b912fad17a76451dc67a587ea0a91ea596d3c5927518732742a82677d8c10716b328
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/theme-search-algolia@npm:3.4.0"
+"@docusaurus/theme-search-algolia@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/theme-search-algolia@npm:3.5.2-canary-6122"
   dependencies:
     "@docsearch/react": "npm:^3.5.2"
-    "@docusaurus/core": "npm:3.4.0"
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/plugin-content-docs": "npm:3.4.0"
-    "@docusaurus/theme-common": "npm:3.4.0"
-    "@docusaurus/theme-translations": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-validation": "npm:3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-translations": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
     algoliasearch: "npm:^4.18.0"
     algoliasearch-helper: "npm:^3.13.3"
     clsx: "npm:^2.0.0"
@@ -2451,23 +3667,23 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 80437afd52d10a41bdbed818654b0ead643e9fcf736f4a556ce1f882e865d0dee88d81b161f41b9c40b87db0c42d8b3b48841194e28cb0c826cc2f66475b3628
+  checksum: 8a2b5862bfc83354ffaed84a7d1e768730a7c1d004c1c1f5955a312bce061c2b1c22e9e4be202165025f737964f5bff1150ca75f0c7f64e0ae7dcdf90e6f5274
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/theme-translations@npm:3.4.0"
+"@docusaurus/theme-translations@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/theme-translations@npm:3.5.2-canary-6122"
   dependencies:
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
-  checksum: bd4a2e451c368ed7dbb83fb8b98046e87722e628dcdb046766ad5f5e94e5a7c1f959edb5395e8a8526ff088596161026599ca47526e7ca8f976c75129a23a298
+  checksum: 667899feb1ebd48ba984cf04e8109a1ba1c0cfb629f5325f8708bc63a74ec864837c4131bfc0e6e5e5137189141ed2a6881f5140e4a417f9a1afca47ba299a42
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:3.4.0, @docusaurus/types@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/types@npm:3.4.0"
+"@docusaurus/types@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/types@npm:3.5.2-canary-6122"
   dependencies:
     "@mdx-js/mdx": "npm:^3.0.0"
     "@types/history": "npm:^4.7.11"
@@ -2476,18 +3692,18 @@ __metadata:
     joi: "npm:^17.9.2"
     react-helmet-async: "npm:^1.3.0"
     utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.88.1"
+    webpack: "npm:^5.95.0"
     webpack-merge: "npm:^5.9.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: fea2147a919ef1824b6fde6b88eef92d8eefb396c956e586aecef2d1140c3456b0bea871a74c9f040a586313f7ff80ac99d6e96c74dde377fdaa06ebeb67e7ad
+  checksum: 0c18308e2bf3f3865435c697539cd928b47208b3992c29c07a650d74394ef88265099fcc52f457acac4fbeb8b69cec4a9d5a5b0bb12786d56f55751ab12a46b7
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/utils-common@npm:3.4.0"
+"@docusaurus/utils-common@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/utils-common@npm:3.5.2-canary-6122"
   dependencies:
     tslib: "npm:^2.6.0"
   peerDependencies:
@@ -2495,32 +3711,32 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: a3d17e3e504e22972a3344215da9e97b5c5d9813a826146b5aad159953f92e1cd9cfecc9d1e2da22ee6df5be3f4b0cbd8f58071f979d0805b1b680d8e6bd571c
+  checksum: 4f543882365b2600b2ea889a272f75c277e05514545b3de1027fa3e5902323bffaf6f36fa3f876c91102d4dced071fc6e3e22c2157116e07b7b0c070a8c4b413
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/utils-validation@npm:3.4.0"
+"@docusaurus/utils-validation@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/utils-validation@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/utils": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
     fs-extra: "npm:^11.2.0"
     joi: "npm:^17.9.2"
     js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
     tslib: "npm:^2.6.0"
-  checksum: 5dd17ab2c552bbad43bc1f1f92a6ddb865c4b0fe1372ea0524a2e3246559b85e229351f6a899d07e418f37de8fdf61284b3c24e41b47eaefd6e75683f7e22c22
+  checksum: 9771e37b7b326d29c969a0f0ce81625ebde8b705afd0f07582df12d2ee6a7e4bd777fc5bac3a2bb5c396d123834722bd094ebd78947e1ce32ba0c289692ffe23
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:3.4.0, @docusaurus/utils@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@docusaurus/utils@npm:3.4.0"
+"@docusaurus/utils@npm:3.5.2-canary-6122":
+  version: 3.5.2-canary-6122
+  resolution: "@docusaurus/utils@npm:3.5.2-canary-6122"
   dependencies:
-    "@docusaurus/logger": "npm:3.4.0"
-    "@docusaurus/utils-common": "npm:3.4.0"
+    "@docusaurus/logger": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
     "@svgr/webpack": "npm:^8.1.0"
     escape-string-regexp: "npm:^4.0.0"
     file-loader: "npm:^6.2.0"
@@ -2544,7 +3760,7 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: 49f926eedbc3fd56cd6052a2cb22affdc9867dae087eaca0f68642af4f1988354a70e50f34956376808f8e343d2876e8a226cf8234e8e53d37efe786de44274a
+  checksum: 1bc66b704e102ae51da96cbfe7a72f0d21d19ee1f68395a6ebb293198a8f49012c609457d325e2fcc9d6dc44ac65e88674362c92739db29e0c00fc33bae543e5
   languageName: node
   linkType: hard
 
@@ -2882,6 +4098,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@module-federation/runtime-tools@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@module-federation/runtime-tools@npm:0.5.1"
+  dependencies:
+    "@module-federation/runtime": "npm:0.5.1"
+    "@module-federation/webpack-bundler-runtime": "npm:0.5.1"
+  checksum: 3c88a7ac45b369e82ccea104db952ab81709a11733b602cf5f1d35b299d1d2f0ce679afc0fd4105386345e727a8f67e141480f708f244fa8c40f898a917c694b
+  languageName: node
+  linkType: hard
+
+"@module-federation/runtime@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@module-federation/runtime@npm:0.5.1"
+  dependencies:
+    "@module-federation/sdk": "npm:0.5.1"
+  checksum: c5b998fdbf6c8ceee2f204d501f8cbe8b4356e4d0a03e767c49107ff6b2a11a077bb4fd17d042dfb050d483eca1baf9b50663e53d3ee9bd8148865be3bb63dcc
+  languageName: node
+  linkType: hard
+
+"@module-federation/sdk@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@module-federation/sdk@npm:0.5.1"
+  checksum: 7569f53f7e0d64ecfb57750d44dac93ba267f35b18921ff84ef2cc12a600690a28460cb2a5b9f2a3e0218b5e45879c16ab980c48930f82065f2c27f476ac3c6e
+  languageName: node
+  linkType: hard
+
+"@module-federation/webpack-bundler-runtime@npm:0.5.1":
+  version: 0.5.1
+  resolution: "@module-federation/webpack-bundler-runtime@npm:0.5.1"
+  dependencies:
+    "@module-federation/runtime": "npm:0.5.1"
+    "@module-federation/sdk": "npm:0.5.1"
+  checksum: ba09e67a6d8f49a88a1660fbd2553de0d6a3524064cd12870688c79a04ac139ed8faf1657f8f805008b29c56db7c0254b64c0793ffc96d522ab1177d28a365bf
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -3197,6 +4449,129 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rspack/binding-darwin-arm64@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-darwin-arm64@npm:1.0.14"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-darwin-x64@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-darwin-x64@npm:1.0.14"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-arm64-gnu@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:1.0.14"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-arm64-musl@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-linux-arm64-musl@npm:1.0.14"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-x64-gnu@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-linux-x64-gnu@npm:1.0.14"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-linux-x64-musl@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-linux-x64-musl@npm:1.0.14"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-win32-arm64-msvc@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:1.0.14"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-win32-ia32-msvc@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:1.0.14"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rspack/binding-win32-x64-msvc@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding-win32-x64-msvc@npm:1.0.14"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rspack/binding@npm:1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/binding@npm:1.0.14"
+  dependencies:
+    "@rspack/binding-darwin-arm64": "npm:1.0.14"
+    "@rspack/binding-darwin-x64": "npm:1.0.14"
+    "@rspack/binding-linux-arm64-gnu": "npm:1.0.14"
+    "@rspack/binding-linux-arm64-musl": "npm:1.0.14"
+    "@rspack/binding-linux-x64-gnu": "npm:1.0.14"
+    "@rspack/binding-linux-x64-musl": "npm:1.0.14"
+    "@rspack/binding-win32-arm64-msvc": "npm:1.0.14"
+    "@rspack/binding-win32-ia32-msvc": "npm:1.0.14"
+    "@rspack/binding-win32-x64-msvc": "npm:1.0.14"
+  dependenciesMeta:
+    "@rspack/binding-darwin-arm64":
+      optional: true
+    "@rspack/binding-darwin-x64":
+      optional: true
+    "@rspack/binding-linux-arm64-gnu":
+      optional: true
+    "@rspack/binding-linux-arm64-musl":
+      optional: true
+    "@rspack/binding-linux-x64-gnu":
+      optional: true
+    "@rspack/binding-linux-x64-musl":
+      optional: true
+    "@rspack/binding-win32-arm64-msvc":
+      optional: true
+    "@rspack/binding-win32-ia32-msvc":
+      optional: true
+    "@rspack/binding-win32-x64-msvc":
+      optional: true
+  checksum: 5a01ff4334920b981032a8e1bd0819393041e859e97bc889113a9de89caecfc4b7dd62e9c56354c427ae3ecfde6e7c43b107dfff02e5d945dacb130da238c73b
+  languageName: node
+  linkType: hard
+
+"@rspack/core@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@rspack/core@npm:1.0.14"
+  dependencies:
+    "@module-federation/runtime-tools": "npm:0.5.1"
+    "@rspack/binding": "npm:1.0.14"
+    "@rspack/lite-tapable": "npm:1.0.1"
+    caniuse-lite: "npm:^1.0.30001616"
+  peerDependencies:
+    "@swc/helpers": ">=0.5.1"
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 3743c2dd9e7337f06091bf3d6c4462294f379aefb1069a1cf561b178b6dc7d8a294856323aab61e2c15f520bf693377e11bc415322ca8ea045adf84e4daeeba3
+  languageName: node
+  linkType: hard
+
+"@rspack/lite-tapable@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rspack/lite-tapable@npm:1.0.1"
+  checksum: 240b7832965bca5a52d1f03a8539dab5810958ce24b5a670405b2505d81350f10d668f4055648f5918bc18ac033e637bcb7f92189345f0f2f671b546019c2f9e
+  languageName: node
+  linkType: hard
+
 "@sideway/address@npm:^4.1.3":
   version: 4.1.4
   resolution: "@sideway/address@npm:4.1.4"
@@ -3405,6 +4780,248 @@ __metadata:
     "@svgr/plugin-jsx": "npm:8.1.0"
     "@svgr/plugin-svgo": "npm:8.1.0"
   checksum: c6eec5b0cf2fb2ecd3a7a362d272eda35330b17c76802a3481f499b5d07ff8f87b31d2571043bff399b051a1767b1e2e499dbf186104d1c06d76f9f1535fac01
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-arm64@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-darwin-arm64@npm:1.7.39"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-darwin-x64@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-darwin-x64@npm:1.7.39"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm-gnueabihf@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.7.39"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-gnu@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.7.39"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-arm64-musl@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-linux-arm64-musl@npm:1.7.39"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-gnu@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-linux-x64-gnu@npm:1.7.39"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/core-linux-x64-musl@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-linux-x64-musl@npm:1.7.39"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-arm64-msvc@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.7.39"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-ia32-msvc@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.7.39"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/core-win32-x64-msvc@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core-win32-x64-msvc@npm:1.7.39"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/core@npm:^1.7.39":
+  version: 1.7.39
+  resolution: "@swc/core@npm:1.7.39"
+  dependencies:
+    "@swc/core-darwin-arm64": "npm:1.7.39"
+    "@swc/core-darwin-x64": "npm:1.7.39"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.7.39"
+    "@swc/core-linux-arm64-gnu": "npm:1.7.39"
+    "@swc/core-linux-arm64-musl": "npm:1.7.39"
+    "@swc/core-linux-x64-gnu": "npm:1.7.39"
+    "@swc/core-linux-x64-musl": "npm:1.7.39"
+    "@swc/core-win32-arm64-msvc": "npm:1.7.39"
+    "@swc/core-win32-ia32-msvc": "npm:1.7.39"
+    "@swc/core-win32-x64-msvc": "npm:1.7.39"
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/types": "npm:^0.1.13"
+  peerDependencies:
+    "@swc/helpers": "*"
+  dependenciesMeta:
+    "@swc/core-darwin-arm64":
+      optional: true
+    "@swc/core-darwin-x64":
+      optional: true
+    "@swc/core-linux-arm-gnueabihf":
+      optional: true
+    "@swc/core-linux-arm64-gnu":
+      optional: true
+    "@swc/core-linux-arm64-musl":
+      optional: true
+    "@swc/core-linux-x64-gnu":
+      optional: true
+    "@swc/core-linux-x64-musl":
+      optional: true
+    "@swc/core-win32-arm64-msvc":
+      optional: true
+    "@swc/core-win32-ia32-msvc":
+      optional: true
+    "@swc/core-win32-x64-msvc":
+      optional: true
+  peerDependenciesMeta:
+    "@swc/helpers":
+      optional: true
+  checksum: 8b719c6c5ccdf44940ec75889c2c78f6bba61e8226eea2c23f527a839826cf647faa7ea915ff92746cdeb0d64ea70b702d3329bdb91cd5e861059cbbd13c5a76
+  languageName: node
+  linkType: hard
+
+"@swc/counter@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "@swc/counter@npm:0.1.3"
+  checksum: df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
+  languageName: node
+  linkType: hard
+
+"@swc/html-darwin-arm64@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-darwin-arm64@npm:1.7.39"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/html-darwin-x64@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-darwin-x64@npm:1.7.39"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-arm-gnueabihf@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-linux-arm-gnueabihf@npm:1.7.39"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-arm64-gnu@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-linux-arm64-gnu@npm:1.7.39"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-arm64-musl@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-linux-arm64-musl@npm:1.7.39"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-x64-gnu@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-linux-x64-gnu@npm:1.7.39"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@swc/html-linux-x64-musl@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-linux-x64-musl@npm:1.7.39"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@swc/html-win32-arm64-msvc@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-win32-arm64-msvc@npm:1.7.39"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@swc/html-win32-ia32-msvc@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-win32-ia32-msvc@npm:1.7.39"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@swc/html-win32-x64-msvc@npm:1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html-win32-x64-msvc@npm:1.7.39"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@swc/html@npm:^1.7.39":
+  version: 1.7.39
+  resolution: "@swc/html@npm:1.7.39"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+    "@swc/html-darwin-arm64": "npm:1.7.39"
+    "@swc/html-darwin-x64": "npm:1.7.39"
+    "@swc/html-linux-arm-gnueabihf": "npm:1.7.39"
+    "@swc/html-linux-arm64-gnu": "npm:1.7.39"
+    "@swc/html-linux-arm64-musl": "npm:1.7.39"
+    "@swc/html-linux-x64-gnu": "npm:1.7.39"
+    "@swc/html-linux-x64-musl": "npm:1.7.39"
+    "@swc/html-win32-arm64-msvc": "npm:1.7.39"
+    "@swc/html-win32-ia32-msvc": "npm:1.7.39"
+    "@swc/html-win32-x64-msvc": "npm:1.7.39"
+  dependenciesMeta:
+    "@swc/html-darwin-arm64":
+      optional: true
+    "@swc/html-darwin-x64":
+      optional: true
+    "@swc/html-linux-arm-gnueabihf":
+      optional: true
+    "@swc/html-linux-arm64-gnu":
+      optional: true
+    "@swc/html-linux-arm64-musl":
+      optional: true
+    "@swc/html-linux-x64-gnu":
+      optional: true
+    "@swc/html-linux-x64-musl":
+      optional: true
+    "@swc/html-win32-arm64-msvc":
+      optional: true
+    "@swc/html-win32-ia32-msvc":
+      optional: true
+    "@swc/html-win32-x64-msvc":
+      optional: true
+  checksum: df833fb54fd1892d3128ea5eda9216547ddacd85ed13502bc1b90abec734a4c7d01ee0c3a33fabfbcf4d998d6f1875cffeb9cf65da59a9a8e7138b60916611ab
+  languageName: node
+  linkType: hard
+
+"@swc/types@npm:^0.1.13":
+  version: 0.1.13
+  resolution: "@swc/types@npm:0.1.13"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  checksum: d0a50432917048cc69e30c82d1266e052a8e8d05ab202c5d74a5666be3748da4d2f99aaff46d91c0e3d285cf8f55270f8391cd578066fdecc3865733f8d5e14a
   languageName: node
   linkType: hard
 
@@ -4423,6 +6040,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-escapes@npm:^4.3.2":
+  version: 4.3.2
+  resolution: "ansi-escapes@npm:4.3.2"
+  dependencies:
+    type-fest: "npm:^0.21.3"
+  checksum: 8661034456193ffeda0c15c8c564a9636b0c04094b7f78bd01517929c17c504090a60f7a75f949f5af91289c264d3e1001d91492c1bd58efc8e100500ce04de2
+  languageName: node
+  linkType: hard
+
 "ansi-escapes@npm:^6.2.0":
   version: 6.2.0
   resolution: "ansi-escapes@npm:6.2.0"
@@ -4732,16 +6358,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-loader@npm:^9.1.3":
-  version: 9.1.3
-  resolution: "babel-loader@npm:9.1.3"
+"babel-loader@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "babel-loader@npm:9.2.1"
   dependencies:
     find-cache-dir: "npm:^4.0.0"
     schema-utils: "npm:^4.0.0"
   peerDependencies:
     "@babel/core": ^7.12.0
     webpack: ">=5"
-  checksum: 7086e678273b5d1261141dca84ed784caab9f7921c8c24d7278c8ee3088235a9a9fd85caac9f0fa687336cb3c27248ca22dbf431469769b1b995d55aec606992
+  checksum: f1f24ae3c22d488630629240b0eba9c935545f82ff843c214e8f8df66e266492b7a3d4cb34ef9c9721fb174ca222e900799951c3fd82199473bc6bac52ec03a3
   languageName: node
   linkType: hard
 
@@ -4754,7 +6380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.4.10, babel-plugin-polyfill-corejs2@npm:^0.4.6":
+"babel-plugin-polyfill-corejs2@npm:^0.4.10":
   version: 0.4.11
   resolution: "babel-plugin-polyfill-corejs2@npm:0.4.11"
   dependencies:
@@ -4779,26 +6405,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs3@npm:^0.8.5":
-  version: 0.8.6
-  resolution: "babel-plugin-polyfill-corejs3@npm:0.8.6"
+"babel-plugin-polyfill-corejs3@npm:^0.10.6":
+  version: 0.10.6
+  resolution: "babel-plugin-polyfill-corejs3@npm:0.10.6"
   dependencies:
-    "@babel/helper-define-polyfill-provider": "npm:^0.4.3"
-    core-js-compat: "npm:^3.33.1"
+    "@babel/helper-define-polyfill-provider": "npm:^0.6.2"
+    core-js-compat: "npm:^3.38.0"
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 2d9c926fda31d800dea7843d82a41b8914a8aaa67d7fb293dd2594e82cd6ce4c9fc67c9d469587b7c14ba38f5ab5689bdc9c21c268888598f464fe77a5f4c964
-  languageName: node
-  linkType: hard
-
-"babel-plugin-polyfill-regenerator@npm:^0.5.3":
-  version: 0.5.3
-  resolution: "babel-plugin-polyfill-regenerator@npm:0.5.3"
-  dependencies:
-    "@babel/helper-define-polyfill-provider": "npm:^0.4.3"
-  peerDependencies:
-    "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 2bb546582cda1870d19e646a7183baeb2cccd56e0ef3e4eaeabd28e120daf17cb87399194a9ccdcf32506bcaa68d23e73440fc8ab990a7a0f8c5a77c12d5d4bc
+  checksum: 360ac9054a57a18c540059dc627ad5d84d15f79790cb3d84d19a02eec7188c67d08a07db789c3822d6f5df22d918e296d1f27c4055fec2e287d328f09ea8a78a
   languageName: node
   linkType: hard
 
@@ -4970,6 +6585,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:^4.23.3, browserslist@npm:^4.24.0, browserslist@npm:^4.24.2":
+  version: 4.24.2
+  resolution: "browserslist@npm:4.24.2"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001669"
+    electron-to-chromium: "npm:^1.5.41"
+    node-releases: "npm:^2.0.18"
+    update-browserslist-db: "npm:^1.1.1"
+  bin:
+    browserslist: cli.js
+  checksum: f8a9d78bbabe466c57ffd5c50a9e5582a5df9aa68f43078ca62a9f6d0d6c70ba72eca72d0a574dbf177cf55cdca85a46f7eb474917a47ae5398c66f8b76f7d1c
+  languageName: node
+  linkType: hard
+
 "buffer-crc32@npm:~0.2.3":
   version: 0.2.13
   resolution: "buffer-crc32@npm:0.2.13"
@@ -5124,6 +6753,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001616, caniuse-lite@npm:^1.0.30001669":
+  version: 1.0.30001669
+  resolution: "caniuse-lite@npm:1.0.30001669"
+  checksum: cd0b481bb997703cb7651e55666b4aa4e7b4ecf9784796e2393179a15e55c71a6abc6ff865c922bbd3bbfa4a4bf0530d8da13989b97ff8c7850c8a5bd4e00491
+  languageName: node
+  linkType: hard
+
 "ccount@npm:^2.0.0":
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
@@ -5215,7 +6851,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cheerio@npm:^1.0.0-rc.12":
+"cheerio@npm:1.0.0-rc.12":
   version: 1.0.0-rc.12
   resolution: "cheerio@npm:1.0.0-rc.12"
   dependencies:
@@ -5590,10 +7226,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"consola@npm:^2.15.3":
-  version: 2.15.3
-  resolution: "consola@npm:2.15.3"
-  checksum: ba5b3c6960b2eafb9d2ff2325444dd1d4eb53115df46eba823a4e7bfe6afbba0eb34747c0de82c7cd8a939db59b0cb5a8b8a54a94bb2e44feeddc26cefde3622
+"consola@npm:^3.2.3":
+  version: 3.2.3
+  resolution: "consola@npm:3.2.3"
+  checksum: 02972dcb048c337357a3628438e5976b8e45bcec22fdcfbe9cd17622992953c4d695d5152f141464a02deac769b1d23028e8ac87f56483838df7a6bbf8e0f5a2
   languageName: node
   linkType: hard
 
@@ -5682,12 +7318,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.33.1, core-js-compat@npm:^3.36.1":
+"core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.36.1":
   version: 3.37.1
   resolution: "core-js-compat@npm:3.37.1"
   dependencies:
     browserslist: "npm:^4.23.0"
   checksum: 30c6fdbd9ff179cc53951814689b8aabec106e5de6cddfa7a7feacc96b66d415b8eebcf5ec8f7c68ef35c552fe7d39edb8b15b1ce0f27379a272295b6e937061
+  languageName: node
+  linkType: hard
+
+"core-js-compat@npm:^3.38.0, core-js-compat@npm:^3.38.1":
+  version: 3.38.1
+  resolution: "core-js-compat@npm:3.38.1"
+  dependencies:
+    browserslist: "npm:^4.23.3"
+  checksum: 4e2f219354fd268895f79486461a12df96f24ed307321482fe2a43529c5a64e7c16bcba654980ba217d603444f5141d43a79058aeac77511085f065c5da72207
   languageName: node
   linkType: hard
 
@@ -6059,6 +7704,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debounce@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "debounce@npm:1.2.1"
+  checksum: 0b95b2a9d80ed69117d890f8dab8c0f2d6066f8d20edd1d810ae51f8f366a6d4c8b1d56e97dcb9304e93d57de4d5db440d34a03def7dad50403fc3f22bf16808
+  languageName: node
+  linkType: hard
+
 "debug@npm:2.6.9, debug@npm:^2.6.0":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
@@ -6231,6 +7883,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detect-libc@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "detect-libc@npm:1.0.3"
+  bin:
+    detect-libc: ./bin/detect-libc.js
+  checksum: 3849fe7720feb153e4ac9407086956e073f1ce1704488290ef0ca8aab9430a8d48c8a9f8351889e7cdc64e5b1128589501e4fef48f3a4a49ba92cd6d112d0757
+  languageName: node
+  linkType: hard
+
 "detect-node@npm:^2.0.4":
   version: 2.1.0
   resolution: "detect-node@npm:2.1.0"
@@ -6320,8 +7981,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docusaurus-plugin-redoc@workspace:packages/docusaurus-plugin-redoc"
   dependencies:
-    "@docusaurus/types": "npm:^3.4.0"
-    "@docusaurus/utils": "npm:^3.4.0"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
     "@redocly/openapi-core": "npm:1.16.0"
     core-js: "npm:^3.36.0"
     mobx: "npm:^6.12.4"
@@ -6340,10 +8001,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docusaurus-theme-redoc@workspace:packages/docusaurus-theme-redoc"
   dependencies:
-    "@docusaurus/module-type-aliases": "npm:^3.4.0"
-    "@docusaurus/theme-classic": "npm:^3.4.0"
-    "@docusaurus/theme-common": "npm:^3.4.0"
-    "@docusaurus/types": "npm:^3.4.0"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-classic": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6122"
     "@redocly/openapi-core": "npm:1.16.0"
     "@types/lodash": "npm:^4.14.200"
     "@types/postcss-prefix-selector": "npm:^1"
@@ -6509,6 +8170,13 @@ __metadata:
   version: 1.4.815
   resolution: "electron-to-chromium@npm:1.4.815"
   checksum: 84f59b76b1ac16fe1f359720bdaeadcbce34825a7e79e3551ceec6b52d4021e7bd8a56a2cfa4197ba353331df18d0bc2ab449e08c5599eb1b2a7aacaba56f711
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.5.41":
+  version: 1.5.45
+  resolution: "electron-to-chromium@npm:1.5.45"
+  checksum: 659b4b979c9c1a63c170c398775daa269acf5c4117f6590ad4677266fa77a680ebf7792e0eb8dc6d4041550e4ec82ad7dd3aac75543d30535b53bc3c1e4d05ff
   languageName: node
   linkType: hard
 
@@ -6794,6 +8462,13 @@ __metadata:
   version: 3.1.2
   resolution: "escalade@npm:3.1.2"
   checksum: a1e07fea2f15663c30e40b9193d658397846ffe28ce0a3e4da0d8e485fedfeca228ab846aee101a05015829adf39f9934ff45b2a3fca47bed37a29646bd05cd3
+  languageName: node
+  linkType: hard
+
+"escalade@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "escalade@npm:3.2.0"
+  checksum: 9d7169e3965b2f9ae46971afa392f6e5a25545ea30f2e2dd99c9b0a95a3f52b5653681a84f5b2911a413ddad2d7a93d3514165072f349b5ffc59c75a899970d6
   languageName: node
   linkType: hard
 
@@ -7432,15 +9107,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-url-parser@npm:1.1.3":
-  version: 1.1.3
-  resolution: "fast-url-parser@npm:1.1.3"
-  dependencies:
-    punycode: "npm:^1.3.2"
-  checksum: 6d33f46ce9776f7f3017576926207a950ca39bc5eb78fc794404f2288fe494720f9a119084b75569bd9eb09d2b46678bfaf39c191fb2c808ef3c833dc8982752
-  languageName: node
-  linkType: hard
-
 "fastq@npm:^1.6.0":
   version: 1.15.0
   resolution: "fastq@npm:1.15.0"
@@ -7483,6 +9149,15 @@ __metadata:
   dependencies:
     xml-js: "npm:^1.6.11"
   checksum: 6aeee26b92037d9b49e89513696cd9d487ada84b31d707f92ab6d579f5cf347353474722727ec0a2d7bcf4ea0829a02d9c7774aacae7709de35c2ea48a8a0d80
+  languageName: node
+  linkType: hard
+
+"figures@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "figures@npm:3.2.0"
+  dependencies:
+    escape-string-regexp: "npm:^1.0.5"
+  checksum: a3bf94e001be51d3770500789157f067218d4bc681a65e1f69d482de15120bcac822dceb1a7b3803f32e4e3a61a46df44f7f2c8ba95d6375e7491502e0dd3d97
   languageName: node
   linkType: hard
 
@@ -8393,6 +10068,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-escaper@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 034d74029dcca544a34fb6135e98d427acd73019796ffc17383eaa3ec2fe1c0471dcbbc8f8ed39e46e86d43ccd753a160631615e4048285e313569609b66d5b7
+  languageName: node
+  linkType: hard
+
 "html-minifier-terser@npm:^6.0.2":
   version: 6.1.0
   resolution: "html-minifier-terser@npm:6.1.0"
@@ -8441,9 +10123,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-webpack-plugin@npm:^5.5.3":
-  version: 5.5.3
-  resolution: "html-webpack-plugin@npm:5.5.3"
+"html-webpack-plugin@npm:^5.6.0":
+  version: 5.6.3
+  resolution: "html-webpack-plugin@npm:5.6.3"
   dependencies:
     "@types/html-minifier-terser": "npm:^6.0.0"
     html-minifier-terser: "npm:^6.0.2"
@@ -8451,8 +10133,14 @@ __metadata:
     pretty-error: "npm:^4.0.0"
     tapable: "npm:^2.0.0"
   peerDependencies:
+    "@rspack/core": 0.x || 1.x
     webpack: ^5.20.0
-  checksum: 01d302a434e3db9f0e2db370f06300fb613de0fb8bdcafd4693e44c2528b8608621e5e7ca5d8302446db3f20c5f8875f1f675926d469b13ebab139954d241055
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
+  checksum: fd2bf1ac04823526c8b609555d027b38b9d61b4ba9f5c8116a37cc6b62d5b86cab1f478616e8c5344fee13663d2566f5c470c66265ecb1e9574dc38d0459889d
   languageName: node
   linkType: hard
 
@@ -8712,10 +10400,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infima@npm:0.2.0-alpha.43":
-  version: 0.2.0-alpha.43
-  resolution: "infima@npm:0.2.0-alpha.43"
-  checksum: 24795341f333331a9525eb560b131ba7842278ce6542c913964b55554b9c30364e8c34ed5b31daaed13044cb31f3f1c2d3c2109c653a242cbb87e3ad0f3a03d2
+"infima@npm:0.2.0-alpha.45":
+  version: 0.2.0-alpha.45
+  resolution: "infima@npm:0.2.0-alpha.45"
+  checksum: 5e620f52d4787a0d4f96fd428411138ec09042d2a7e9adc7fc38612a9c57e49dd485ccc4f35bbbcd07f66e63bb2f6fbb6dde35a8351e9a978a7e4e1ebb7f0af0
   languageName: node
   linkType: hard
 
@@ -9120,13 +10808,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
-  languageName: node
-  linkType: hard
-
 "is-reference@npm:^3.0.0":
   version: 3.0.2
   resolution: "is-reference@npm:3.0.2"
@@ -9462,6 +11143,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsesc@npm:^3.0.2, jsesc@npm:~3.0.2":
+  version: 3.0.2
+  resolution: "jsesc@npm:3.0.2"
+  bin:
+    jsesc: bin/jsesc
+  checksum: 8e5a7de6b70a8bd71f9cb0b5a7ade6a73ae6ab55e697c74cc997cede97417a3a65ed86c36f7dd6125fe49766e8386c845023d9e213916ca92c9dfdd56e2babf3
+  languageName: node
+  linkType: hard
+
 "jsesc@npm:~0.5.0":
   version: 0.5.0
   resolution: "jsesc@npm:0.5.0"
@@ -9647,6 +11337,116 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-darwin-arm64@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-darwin-arm64@npm:1.27.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-darwin-x64@npm:1.27.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-freebsd-x64@npm:1.27.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.27.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.27.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.27.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.27.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.27.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.27.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.27.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "lightningcss@npm:1.27.0"
+  dependencies:
+    detect-libc: "npm:^1.0.3"
+    lightningcss-darwin-arm64: "npm:1.27.0"
+    lightningcss-darwin-x64: "npm:1.27.0"
+    lightningcss-freebsd-x64: "npm:1.27.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.27.0"
+    lightningcss-linux-arm64-gnu: "npm:1.27.0"
+    lightningcss-linux-arm64-musl: "npm:1.27.0"
+    lightningcss-linux-x64-gnu: "npm:1.27.0"
+    lightningcss-linux-x64-musl: "npm:1.27.0"
+    lightningcss-win32-arm64-msvc: "npm:1.27.0"
+    lightningcss-win32-x64-msvc: "npm:1.27.0"
+  dependenciesMeta:
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 275a0103c7dc1dfcf8e456a0523d1719a1caff916c45229ec62cdb28a814dce12b7065b88865fb74fc03a2a658ac3361caff5c348f1646313513c125d4f27954
+  languageName: node
+  linkType: hard
+
 "lilconfig@npm:3.0.0":
   version: 3.0.0
   resolution: "lilconfig@npm:3.0.0"
@@ -9783,27 +11583,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.escape@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "lodash.escape@npm:4.0.1"
-  checksum: ba1effab9aea7e20ee69b26cbfeb41c73da2eb4d2ab1c261aaf53dd0902ce1afc2f0b34fb24bc69c1d2dd201c332e1d1eb696092fc844a2c5c8e7ccd1ca32014
-  languageName: node
-  linkType: hard
-
-"lodash.flatten@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.flatten@npm:4.4.0"
-  checksum: a2b192f220b0b6c78a6c0175e96bad888b9e0f2a887a8e8c1d0c29d03231fbf110bbb9be0d9de5f936537d143eeb9d5b4f44c4a44f5592c195bf2fae6a6b1e3a
-  languageName: node
-  linkType: hard
-
-"lodash.invokemap@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "lodash.invokemap@npm:4.6.0"
-  checksum: 70e629f78dc0e7aabfabf0ef575cc0b3d3b207699a5c91788bf5363d8f53764b80afd5c1985a98043ecc23095a145b271101626ed62dbb785ffcb22237b731c9
-  languageName: node
-  linkType: hard
-
 "lodash.isequal@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.isequal@npm:4.5.0"
@@ -9825,13 +11604,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.pullall@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "lodash.pullall@npm:4.2.0"
-  checksum: ec2aa1a1eea37226ef7b69041779221ef6fdc6472589dd4d89cec2a0f3d067301a0274abc6a0522797f9958497c79d8bc754825f23ea21e0e053ef8bdfe742ad
-  languageName: node
-  linkType: hard
-
 "lodash.startcase@npm:^4.4.0":
   version: 4.4.0
   resolution: "lodash.startcase@npm:4.4.0"
@@ -9843,13 +11615,6 @@ __metadata:
   version: 4.5.0
   resolution: "lodash.uniq@npm:4.5.0"
   checksum: 86246ca64ac0755c612e5df6d93cfe92f9ecac2e5ff054b965efbbb1d9a647b6310969e78545006f70f52760554b03233ad0103324121ae31474c20d5f7a2812
-  languageName: node
-  linkType: hard
-
-"lodash.uniqby@npm:^4.7.0":
-  version: 4.7.0
-  resolution: "lodash.uniqby@npm:4.7.0"
-  checksum: 256616bd1bd6be84d8a5eceb61338a0ab8d8b34314ba7bfd5f0de35227d0e2c1e659c61ff4ac31eba6a664085cc7e397bc34c3534fba208102db660a4f98f211
   languageName: node
   linkType: hard
 
@@ -9979,6 +11744,15 @@ __metadata:
   version: 2.0.0
   resolution: "markdown-extensions@npm:2.0.0"
   checksum: ec4ffcb0768f112e778e7ac74cb8ef22a966c168c3e6c29829f007f015b0a0b5c79c73ee8599a0c72e440e7f5cfdbf19e80e2d77b9a313b8f66e180a330cf1b2
+  languageName: node
+  linkType: hard
+
+"markdown-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "markdown-table@npm:2.0.0"
+  dependencies:
+    repeat-string: "npm:^1.0.0"
+  checksum: 8018cd1a1733ffda916a0548438e50f3d21b6c6b71fb23696b33c0b5922a8cc46035eb4b204a59c6054f063076f934461ae094599656a63f87c1c3a80bd3c229
   languageName: node
   linkType: hard
 
@@ -10895,14 +12669,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^2.7.6":
-  version: 2.7.6
-  resolution: "mini-css-extract-plugin@npm:2.7.6"
+"mini-css-extract-plugin@npm:^2.9.1":
+  version: 2.9.1
+  resolution: "mini-css-extract-plugin@npm:2.9.1"
   dependencies:
     schema-utils: "npm:^4.0.0"
+    tapable: "npm:^2.2.1"
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 1f718bfdcb7c2bf5e4336f694e5576432149d63f9dacaf94eae38ad046534050471a712a2d1bedf95e1722a2d3b56c3361d7352849e802e4875e716885e952c3
+  checksum: a4a0c73a054254784b9d39a3a4f117691600355125242dfc46ced0912b4937050823478bdbf403b5392c21e2fb2203902b41677d67c7d668f77b985b594e94c6
   languageName: node
   linkType: hard
 
@@ -11246,6 +13021,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-releases@npm:^2.0.18":
+  version: 2.0.18
+  resolution: "node-releases@npm:2.0.18"
+  checksum: 241e5fa9556f1c12bafb83c6c3e94f8cf3d8f2f8f904906ecef6e10bcaa1d59aa61212d4651bec70052015fc54bd3fdcdbe7fc0f638a17e6685aa586c076ec4e
+  languageName: node
+  linkType: hard
+
 "nodemon@npm:^3.1.0":
   version: 3.1.0
   resolution: "nodemon@npm:3.1.0"
@@ -11350,6 +13132,18 @@ __metadata:
   dependencies:
     boolbase: "npm:^1.0.0"
   checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
+  languageName: node
+  linkType: hard
+
+"null-loader@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "null-loader@npm:4.0.1"
+  dependencies:
+    loader-utils: "npm:^2.0.0"
+    schema-utils: "npm:^3.0.0"
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: eeb4c4dd2f8f41e46f5665e4500359109e95ec1028a178a60e0161984906572da7dd87644bcc3cb29f0125d77e2b2508fb4f3813cfb1c6604a15865beb4b987b
   languageName: node
   linkType: hard
 
@@ -11927,10 +13721,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:2.2.1":
-  version: 2.2.1
-  resolution: "path-to-regexp@npm:2.2.1"
-  checksum: 1a7125f8c1b5904d556a29722333219df4aa779039e903efe2fbfe0cc3ae9246672846fc8ad285664020b70e434347e0bc9af691fd7d61df8eaa7b018dcd56fb
+"path-to-regexp@npm:3.3.0":
+  version: 3.3.0
+  resolution: "path-to-regexp@npm:3.3.0"
+  checksum: 8d256383af8db66233ee9027cfcbf8f5a68155efbb4f55e784279d3ab206dcaee554ddb72ff0dae97dd2882af9f7fa802634bb7cffa2e796927977e31b829259
   languageName: node
   linkType: hard
 
@@ -11986,6 +13780,13 @@ __metadata:
   version: 1.0.1
   resolution: "picocolors@npm:1.0.1"
   checksum: fa68166d1f56009fc02a34cdfd112b0dd3cf1ef57667ac57281f714065558c01828cdf4f18600ad6851cbe0093952ed0660b1e0156bddf2184b6aaf5817553a5
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: e1cf46bf84886c79055fdfa9dcb3e4711ad259949e3565154b004b260cd356c5d54b31a1437ce9782624bf766272fe6b0154f5f0c744fb7af5d454d2b60db045
   languageName: node
   linkType: hard
 
@@ -12701,13 +14502,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^1.3.2":
-  version: 1.4.1
-  resolution: "punycode@npm:1.4.1"
-  checksum: af2700dde1a116791ff8301348ff344c47d6c224e875057237d1b5112035655fb07a6175cfdb8bf0e3a8cdfd2dc82b3a622e0aefd605566c0e949a6d0d1256a4
-  languageName: node
-  linkType: hard
-
 "punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -13155,10 +14949,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus-website@workspace:website"
   dependencies:
-    "@docusaurus/core": "npm:^3.4.0"
-    "@docusaurus/preset-classic": "npm:^3.4.0"
-    "@docusaurus/theme-common": "npm:^3.4.0"
-    "@docusaurus/utils": "npm:^3.4.0"
+    "@docusaurus/core": "npm:3.5.2-canary-6122"
+    "@docusaurus/faster": "npm:3.5.2-canary-6122"
+    "@docusaurus/preset-classic": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
     "@percy/cli": "npm:^1.28.8"
     "@types/react": "npm:^18.3.3"
     clsx: "npm:^1.2.1"
@@ -13172,8 +14967,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus@workspace:packages/redocusaurus"
   dependencies:
-    "@docusaurus/theme-common": "npm:^3.4.0"
-    "@docusaurus/utils": "npm:^3.4.0"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
+    "@docusaurus/utils": "npm:3.5.2-canary-6122"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     docusaurus-plugin-redoc: "npm:2.1.1"
@@ -13215,6 +15010,15 @@ __metadata:
   dependencies:
     regenerate: "npm:^1.4.2"
   checksum: b855152efdcca0ecc37ceb0cb6647a544344555fc293af3b57191b918e1bc9c95ee404a9a64a1d692bf66d45850942c29d93f2740c0d1980d3a8ea2ca63b184e
+  languageName: node
+  linkType: hard
+
+"regenerate-unicode-properties@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "regenerate-unicode-properties@npm:10.2.0"
+  dependencies:
+    regenerate: "npm:^1.4.2"
+  checksum: 9150eae6fe04a8c4f2ff06077396a86a98e224c8afad8344b1b656448e89e84edcd527e4b03aa5476774129eb6ad328ed684f9c1459794a935ec0cc17ce14329
   languageName: node
   linkType: hard
 
@@ -13267,6 +15071,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regexpu-core@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "regexpu-core@npm:6.1.1"
+  dependencies:
+    regenerate: "npm:^1.4.2"
+    regenerate-unicode-properties: "npm:^10.2.0"
+    regjsgen: "npm:^0.8.0"
+    regjsparser: "npm:^0.11.0"
+    unicode-match-property-ecmascript: "npm:^2.0.0"
+    unicode-match-property-value-ecmascript: "npm:^2.1.0"
+  checksum: 6a7ffb42781cacedd7df3c47c72e2d725401a699855be94a37ece5e29d3f25ab3abdd81d73f2d9d32ebc4d41bd25e3c3cc21e5284203faf19e60943adc55252d
+  languageName: node
+  linkType: hard
+
 "registry-auth-token@npm:^5.0.1":
   version: 5.0.2
   resolution: "registry-auth-token@npm:5.0.2"
@@ -13282,6 +15100,24 @@ __metadata:
   dependencies:
     rc: "npm:1.2.8"
   checksum: 33712aa1b489aab7aba2191c1cdadfdd71f5bf166d4792d81744a6be332c160bd7d9273af8269d8a01284b9562f14a5b31b7abcf7ad9306c44887ecff51c89ab
+  languageName: node
+  linkType: hard
+
+"regjsgen@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "regjsgen@npm:0.8.0"
+  checksum: b930f03347e4123c917d7b40436b4f87f625b8dd3e705b447ddd44804e4616c3addb7453f0902d6e914ab0446c30e816e445089bb641a4714237fe8141a0ef9d
+  languageName: node
+  linkType: hard
+
+"regjsparser@npm:^0.11.0":
+  version: 0.11.1
+  resolution: "regjsparser@npm:0.11.1"
+  dependencies:
+    jsesc: "npm:~3.0.2"
+  bin:
+    regjsparser: bin/parser
+  checksum: 06295f1666f8e378c3b70eb01578b46e075eee0556865a297497ab40753f04cce526e96513b18e21e66b79c972e7377bd3b5caa86935ed5d736e9b3e0f857363
   languageName: node
   linkType: hard
 
@@ -13421,6 +15257,13 @@ __metadata:
     lodash: "npm:^4.17.21"
     strip-ansi: "npm:^6.0.1"
   checksum: 434bd56d9930dd344bcba3ef7683f3dd893396b6bc7e8caa551a4cacbe75a9466dc6cf3d75bc324a5979278a73ef968d7854f8f660dbf1a52c38a73f1fb59b20
+  languageName: node
+  linkType: hard
+
+"repeat-string@npm:^1.0.0":
+  version: 1.6.1
+  resolution: "repeat-string@npm:1.6.1"
+  checksum: 1b809fc6db97decdc68f5b12c4d1a671c8e3f65ec4a40c238bc5200e44e85bcc52a54f78268ab9c29fcf5fe4f1343e805420056d1f30fa9a9ee4c2d93e3cc6c0
   languageName: node
   linkType: hard
 
@@ -13819,19 +15662,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serve-handler@npm:^6.1.5":
-  version: 6.1.5
-  resolution: "serve-handler@npm:6.1.5"
+"serve-handler@npm:^6.1.6":
+  version: 6.1.6
+  resolution: "serve-handler@npm:6.1.6"
   dependencies:
     bytes: "npm:3.0.0"
     content-disposition: "npm:0.5.2"
-    fast-url-parser: "npm:1.1.3"
     mime-types: "npm:2.1.18"
     minimatch: "npm:3.1.2"
     path-is-inside: "npm:1.0.2"
-    path-to-regexp: "npm:2.2.1"
+    path-to-regexp: "npm:3.3.0"
     range-parser: "npm:1.2.0"
-  checksum: cab6f381d380ae77ae6da017b5c7b1c25d8f0bed00cf509a18bc768c1830a0043ce53668390ad8a84366e47b353b3f1f7c9d10c7167886179f2e89cb95243a90
+  checksum: 7e7d93eb7e69fcd9f9c5afc2ef2b46cb0072b4af13cbabef9bca725afb350ddae6857d8c8be2c256f7ce1f7677c20347801399c11caa5805c0090339f894e8f2
   languageName: node
   linkType: hard
 
@@ -14328,10 +16170,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"std-env@npm:^3.0.1":
-  version: 3.4.3
-  resolution: "std-env@npm:3.4.3"
-  checksum: 3087e9b2f6f9f40f1562b765c2d0768ad12f04a4d039fa5848e9e951263266b533590464e5d90e412680ec37e4febabf0c8fb3d15c4c7b8c5eb21ebcb09bf393
+"std-env@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "std-env@npm:3.7.0"
+  checksum: 6ee0cca1add3fd84656b0002cfbc5bfa20340389d9ba4720569840f1caa34bce74322aef4c93f046391583e50649d0cf81a5f8fe1d411e50b659571690a45f12
   languageName: node
   linkType: hard
 
@@ -14667,6 +16509,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"swc-loader@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "swc-loader@npm:0.2.6"
+  dependencies:
+    "@swc/counter": "npm:^0.1.3"
+  peerDependencies:
+    "@swc/core": ^1.2.147
+    webpack: ">=2"
+  checksum: fe90948c02a51bb8ffcff1ce3590e01dc12860b0bb7c9e22052b14fa846ed437781ae265614a5e14344bea22001108780f00a6e350e28c0b3499bc4cd11335fb
+  languageName: node
+  linkType: hard
+
 "synckit@npm:^0.8.6":
   version: 0.8.8
   resolution: "synckit@npm:0.8.8"
@@ -14684,7 +16538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0":
+"tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
   checksum: 1769336dd21481ae6347611ca5fca47add0962fd8e80466515032125eca0084a4f0ede11e65341b9c0018ef4e1cf1ad820adbb0fba7cc99865c6005734000b0a
@@ -14907,6 +16761,13 @@ __metadata:
   version: 0.20.2
   resolution: "type-fest@npm:0.20.2"
   checksum: 8907e16284b2d6cfa4f4817e93520121941baba36b39219ea36acfe64c86b9dbc10c9941af450bd60832c8f43464974d51c0957f9858bc66b952b66b6914cbb9
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: f4254070d9c3d83a6e573bcb95173008d73474ceadbbf620dd32d273940ca18734dff39c2b2480282df9afe5d1675ebed5499a00d791758748ea81f61a38961f
   languageName: node
   linkType: hard
 
@@ -15237,6 +17098,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"update-browserslist-db@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "update-browserslist-db@npm:1.1.1"
+  dependencies:
+    escalade: "npm:^3.2.0"
+    picocolors: "npm:^1.1.0"
+  peerDependencies:
+    browserslist: ">= 4.21.0"
+  bin:
+    update-browserslist-db: cli.js
+  checksum: 7678dd8609750588d01aa7460e8eddf2ff9d16c2a52fb1811190e0d056390f1fdffd94db3cf8fb209cf634ab4fa9407886338711c71cc6ccade5eeb22b093734
+  languageName: node
+  linkType: hard
+
 "update-notifier@npm:^6.0.2":
   version: 6.0.2
   resolution: "update-notifier@npm:6.0.2"
@@ -15425,34 +17300,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^4.9.0":
-  version: 4.9.1
-  resolution: "webpack-bundle-analyzer@npm:4.9.1"
+"webpack-bundle-analyzer@npm:^4.10.2":
+  version: 4.10.2
+  resolution: "webpack-bundle-analyzer@npm:4.10.2"
   dependencies:
     "@discoveryjs/json-ext": "npm:0.5.7"
     acorn: "npm:^8.0.4"
     acorn-walk: "npm:^8.0.0"
     commander: "npm:^7.2.0"
+    debounce: "npm:^1.2.1"
     escape-string-regexp: "npm:^4.0.0"
     gzip-size: "npm:^6.0.0"
-    is-plain-object: "npm:^5.0.0"
-    lodash.debounce: "npm:^4.0.8"
-    lodash.escape: "npm:^4.0.1"
-    lodash.flatten: "npm:^4.4.0"
-    lodash.invokemap: "npm:^4.6.0"
-    lodash.pullall: "npm:^4.2.0"
-    lodash.uniqby: "npm:^4.7.0"
+    html-escaper: "npm:^2.0.2"
     opener: "npm:^1.5.2"
     picocolors: "npm:^1.0.0"
     sirv: "npm:^2.0.3"
     ws: "npm:^7.3.1"
   bin:
     webpack-bundle-analyzer: lib/bin/analyzer.js
-  checksum: 1126f7ad46d926316f467523c6e512e063b9d82e3252a74b4f997f69f32005735e51a0f58345db6921a37c876256effcdb3b4cc1b2053cd91d1fe583eda18fea
+  checksum: cb7ff9d01dc04ef23634f439ab9fe739e022cce5595cb340e01d106ed474605ce4ef50b11b47e444507d341b16650dcb3610e88944020ca6c1c38e88072d43ba
   languageName: node
   linkType: hard
 
-"webpack-dev-middleware@npm:^5.3.1":
+"webpack-dev-middleware@npm:^5.3.4":
   version: 5.3.4
   resolution: "webpack-dev-middleware@npm:5.3.4"
   dependencies:
@@ -15467,9 +17337,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^4.15.1":
-  version: 4.15.1
-  resolution: "webpack-dev-server@npm:4.15.1"
+"webpack-dev-server@npm:^4.15.2":
+  version: 4.15.2
+  resolution: "webpack-dev-server@npm:4.15.2"
   dependencies:
     "@types/bonjour": "npm:^3.5.9"
     "@types/connect-history-api-fallback": "npm:^1.3.5"
@@ -15499,7 +17369,7 @@ __metadata:
     serve-index: "npm:^1.9.1"
     sockjs: "npm:^0.3.24"
     spdy: "npm:^4.0.2"
-    webpack-dev-middleware: "npm:^5.3.1"
+    webpack-dev-middleware: "npm:^5.3.4"
     ws: "npm:^8.13.0"
   peerDependencies:
     webpack: ^4.37.0 || ^5.0.0
@@ -15510,7 +17380,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: fd6dfb6c71eb94696b21930ea4c2f25e95ba85fac1bbc15aa5d03af0a90712eba057901fa9131ed3e901665c95b2379208279aca61e9c48e7cda276c3caa95dd
+  checksum: 86ca4fb49d2a264243b2284c6027a9a91fd7d47737bbb4096e873be8a3f8493a9577b1535d7cc84de1ee991da7da97686c85788ccac547b0f5cf5c7686aacee9
   languageName: node
   linkType: hard
 
@@ -15522,6 +17392,17 @@ __metadata:
     flat: "npm:^5.0.2"
     wildcard: "npm:^2.0.0"
   checksum: fa46ab200f17d06c7cb49fc37ad91f15769753953c9724adac1061fa305a2a223cb37c3ed25a5f501580c91f11a0800990fe3814c70a77bf1aa5b3fca45a2ac6
+  languageName: node
+  linkType: hard
+
+"webpack-merge@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "webpack-merge@npm:6.0.1"
+  dependencies:
+    clone-deep: "npm:^4.0.1"
+    flat: "npm:^5.0.2"
+    wildcard: "npm:^2.0.1"
+  checksum: 39ab911c26237922295d9b3d0617c8ea0c438c35a3b21b05506616a10423f5ece1962bccbedec932c5db61af57999b6d055d56d1f1755c63e2701bd4a55c3887
   languageName: node
   linkType: hard
 
@@ -15568,17 +17449,57 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpackbar@npm:^5.0.2":
-  version: 5.0.2
-  resolution: "webpackbar@npm:5.0.2"
+"webpack@npm:^5.95.0":
+  version: 5.95.0
+  resolution: "webpack@npm:5.95.0"
   dependencies:
-    chalk: "npm:^4.1.0"
-    consola: "npm:^2.15.3"
+    "@types/estree": "npm:^1.0.5"
+    "@webassemblyjs/ast": "npm:^1.12.1"
+    "@webassemblyjs/wasm-edit": "npm:^1.12.1"
+    "@webassemblyjs/wasm-parser": "npm:^1.12.1"
+    acorn: "npm:^8.7.1"
+    acorn-import-attributes: "npm:^1.9.5"
+    browserslist: "npm:^4.21.10"
+    chrome-trace-event: "npm:^1.0.2"
+    enhanced-resolve: "npm:^5.17.1"
+    es-module-lexer: "npm:^1.2.1"
+    eslint-scope: "npm:5.1.1"
+    events: "npm:^3.2.0"
+    glob-to-regexp: "npm:^0.4.1"
+    graceful-fs: "npm:^4.2.11"
+    json-parse-even-better-errors: "npm:^2.3.1"
+    loader-runner: "npm:^4.2.0"
+    mime-types: "npm:^2.1.27"
+    neo-async: "npm:^2.6.2"
+    schema-utils: "npm:^3.2.0"
+    tapable: "npm:^2.1.1"
+    terser-webpack-plugin: "npm:^5.3.10"
+    watchpack: "npm:^2.4.1"
+    webpack-sources: "npm:^3.2.3"
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 0377ad3a550b041f26237c96fb55754625b0ce6bae83c1c2447e3262ad056b0b0ad770dcbb92b59f188e9a2bd56155ce910add17dcf023cfbe78bdec774380c1
+  languageName: node
+  linkType: hard
+
+"webpackbar@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "webpackbar@npm:6.0.1"
+  dependencies:
+    ansi-escapes: "npm:^4.3.2"
+    chalk: "npm:^4.1.2"
+    consola: "npm:^3.2.3"
+    figures: "npm:^3.2.0"
+    markdown-table: "npm:^2.0.0"
     pretty-time: "npm:^1.1.0"
-    std-env: "npm:^3.0.1"
+    std-env: "npm:^3.7.0"
+    wrap-ansi: "npm:^7.0.0"
   peerDependencies:
     webpack: 3 || 4 || 5
-  checksum: 059d5bed5c52a40636e29271285de4a8f9ac2ebef8941b896fc3fb858df2bf6f7c2fdedab80d6637626b91e03686c553ff644af47deb5c44fedf32edf558396f
+  checksum: 9da47f8dcbc9173b19e41e3e1049fa451b0c02095ffa003e8c09c56aa2cc544334d1c6fff0797162a807b29090db9cf9a269cd5ec453196142543f9275cbbf70
   languageName: node
   linkType: hard
 
@@ -15720,7 +17641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wildcard@npm:^2.0.0":
+"wildcard@npm:^2.0.0, wildcard@npm:^2.0.1":
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: e0c60a12a219e4b12065d1199802d81c27b841ed6ad6d9d28240980c73ceec6f856771d575af367cbec2982d9ae7838759168b551776577f155044f5a5ba843c

--- a/yarn.lock
+++ b/yarn.lock
@@ -3212,6 +3212,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/babel@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/babel@npm:3.5.2-canary-6125"
+  dependencies:
+    "@babel/core": "npm:^7.25.9"
+    "@babel/generator": "npm:^7.25.9"
+    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
+    "@babel/plugin-transform-runtime": "npm:^7.25.9"
+    "@babel/preset-env": "npm:^7.25.9"
+    "@babel/preset-react": "npm:^7.25.9"
+    "@babel/preset-typescript": "npm:^7.25.9"
+    "@babel/runtime": "npm:^7.25.9"
+    "@babel/runtime-corejs3": "npm:^7.25.9"
+    "@babel/traverse": "npm:^7.25.9"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    babel-plugin-dynamic-import-node: "npm:^2.3.3"
+    fs-extra: "npm:^11.1.1"
+    tslib: "npm:^2.6.0"
+  checksum: 46c9fe01a06d1c67b47b4544584bcbe97221dd992035269d7e776978b1301ec65ac345f9461ef2213c1604f10c8e9d90aeadfbe2120d18ccf88231666b53795b
+  languageName: node
+  linkType: hard
+
 "@docusaurus/bundler@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/bundler@npm:3.5.2-canary-6122"
@@ -3247,6 +3270,44 @@ __metadata:
     "@docusaurus/faster":
       optional: true
   checksum: 8e089c79304330b5f6730f6af7317e7083ef6df29b40b4896c3e1c531b355addf0bc70adea35a69ffc1ddc5f3bd10f64594f887606712e54f2be161f57695077
+  languageName: node
+  linkType: hard
+
+"@docusaurus/bundler@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/bundler@npm:3.5.2-canary-6125"
+  dependencies:
+    "@babel/core": "npm:^7.25.9"
+    "@docusaurus/babel": "npm:3.5.2-canary-6125"
+    "@docusaurus/cssnano-preset": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    autoprefixer: "npm:^10.4.14"
+    babel-loader: "npm:^9.2.1"
+    clean-css: "npm:^5.3.2"
+    copy-webpack-plugin: "npm:^11.0.0"
+    css-loader: "npm:^6.8.1"
+    css-minimizer-webpack-plugin: "npm:^5.0.1"
+    cssnano: "npm:^6.1.2"
+    file-loader: "npm:^6.2.0"
+    html-minifier-terser: "npm:^7.2.0"
+    mini-css-extract-plugin: "npm:^2.9.1"
+    null-loader: "npm:^4.0.1"
+    postcss: "npm:^8.4.26"
+    postcss-loader: "npm:^7.3.3"
+    react-dev-utils: "npm:^12.0.1"
+    terser-webpack-plugin: "npm:^5.3.9"
+    tslib: "npm:^2.6.0"
+    url-loader: "npm:^4.1.1"
+    webpack: "npm:^5.95.0"
+    webpackbar: "npm:^6.0.1"
+  peerDependencies:
+    "@docusaurus/faster": 3.5.2
+  peerDependenciesMeta:
+    "@docusaurus/faster":
+      optional: true
+  checksum: 54504a5becb64f327c668906b76177b9a1a7265b765f574648abf7182c52e6f5edc6d3eac830284820435b2dc7dc06dc307d02733edf9ba558a276be45e1090a
   languageName: node
   linkType: hard
 
@@ -3307,6 +3368,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/core@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/core@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/babel": "npm:3.5.2-canary-6125"
+    "@docusaurus/bundler": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    boxen: "npm:^6.2.1"
+    chalk: "npm:^4.1.2"
+    chokidar: "npm:^3.5.3"
+    cli-table3: "npm:^0.6.3"
+    combine-promises: "npm:^1.1.0"
+    commander: "npm:^5.1.0"
+    core-js: "npm:^3.31.1"
+    del: "npm:^6.1.1"
+    detect-port: "npm:^1.5.1"
+    escape-html: "npm:^1.0.3"
+    eta: "npm:^2.2.0"
+    eval: "npm:^0.1.8"
+    fs-extra: "npm:^11.1.1"
+    html-tags: "npm:^3.3.1"
+    html-webpack-plugin: "npm:^5.6.0"
+    leven: "npm:^3.1.0"
+    lodash: "npm:^4.17.21"
+    p-map: "npm:^4.0.0"
+    prompts: "npm:^2.4.2"
+    react-dev-utils: "npm:^12.0.1"
+    react-helmet-async: "npm:^1.3.0"
+    react-loadable: "npm:@docusaurus/react-loadable@6.0.0"
+    react-loadable-ssr-addon-v5-slorber: "npm:^1.0.1"
+    react-router: "npm:^5.3.4"
+    react-router-config: "npm:^5.1.1"
+    react-router-dom: "npm:^5.3.4"
+    rtl-detect: "npm:^1.0.4"
+    semver: "npm:^7.5.4"
+    serve-handler: "npm:^6.1.6"
+    shelljs: "npm:^0.8.5"
+    tslib: "npm:^2.6.0"
+    update-notifier: "npm:^6.0.2"
+    webpack: "npm:^5.95.0"
+    webpack-bundle-analyzer: "npm:^4.10.2"
+    webpack-dev-server: "npm:^4.15.2"
+    webpack-merge: "npm:^6.0.1"
+  peerDependencies:
+    "@mdx-js/react": ^3.0.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  bin:
+    docusaurus: bin/docusaurus.mjs
+  checksum: 146fb5376cf61f36092d7662095db4197ce4f6acce42c7fdf14f3ccd0ceed11143b179197bd587e06aebcd882af473a2fdf350b1da7acc79fe413c3d8c3819c3
+  languageName: node
+  linkType: hard
+
 "@docusaurus/cssnano-preset@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/cssnano-preset@npm:3.5.2-canary-6122"
@@ -3316,6 +3434,18 @@ __metadata:
     postcss-sort-media-queries: "npm:^5.2.0"
     tslib: "npm:^2.6.0"
   checksum: 8c22fa55aa8d4de56b0d5b5dbfd3b321728a178e36719384650bad6fd5975a20b285ce888479d83e6e82d7beb5c674981b5ecab0f5fbf307e27e9153c55df9e5
+  languageName: node
+  linkType: hard
+
+"@docusaurus/cssnano-preset@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/cssnano-preset@npm:3.5.2-canary-6125"
+  dependencies:
+    cssnano-preset-advanced: "npm:^6.1.2"
+    postcss: "npm:^8.4.38"
+    postcss-sort-media-queries: "npm:^5.2.0"
+    tslib: "npm:^2.6.0"
+  checksum: ba04013e7ec5b67a3e3e3d117fd37740f05deb9e488d8d2b48d2223a6ea7f9daf8af2670ef93bbf4b7a142eb4dbdaad2d401ad6f40c2720f97302b606498629c
   languageName: node
   linkType: hard
 
@@ -3343,6 +3473,16 @@ __metadata:
     chalk: "npm:^4.1.2"
     tslib: "npm:^2.6.0"
   checksum: 0f3d84780ad5cd9b80bf36b2328f07eedd8ff592dd341151124616497fbf09495cb98418058f129e4e68b01f403b4c897f25f485be5add2feb22ee5e40841155
+  languageName: node
+  linkType: hard
+
+"@docusaurus/logger@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/logger@npm:3.5.2-canary-6125"
+  dependencies:
+    chalk: "npm:^4.1.2"
+    tslib: "npm:^2.6.0"
+  checksum: ae844663c74f8d08bcca5a06ad8699f6e5e73c67b9b9c365ec6bd6eede027b035b9e9e7035b4615146319fd87ae042209754a75131530074d52fdc598f2f0f8b
   languageName: node
   linkType: hard
 
@@ -3381,6 +3521,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/mdx-loader@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/mdx-loader@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@mdx-js/mdx": "npm:^3.0.0"
+    "@slorber/remark-comment": "npm:^1.0.0"
+    escape-html: "npm:^1.0.3"
+    estree-util-value-to-estree: "npm:^3.0.1"
+    file-loader: "npm:^6.2.0"
+    fs-extra: "npm:^11.1.1"
+    image-size: "npm:^1.0.2"
+    mdast-util-mdx: "npm:^3.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    rehype-raw: "npm:^7.0.0"
+    remark-directive: "npm:^3.0.0"
+    remark-emoji: "npm:^4.0.0"
+    remark-frontmatter: "npm:^5.0.0"
+    remark-gfm: "npm:^4.0.0"
+    stringify-object: "npm:^3.3.0"
+    tslib: "npm:^2.6.0"
+    unified: "npm:^11.0.3"
+    unist-util-visit: "npm:^5.0.0"
+    url-loader: "npm:^4.1.1"
+    vfile: "npm:^6.0.1"
+    webpack: "npm:^5.88.1"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 62f5d40ed9dc1ab8cc7e9590b333d701b64f95b1b37e963f0f3dfe9a36607ae55087482fa0dd53aaff23f518a4df150b083fb22e70e695a1ac4ac41464d54951
+  languageName: node
+  linkType: hard
+
 "@docusaurus/module-type-aliases@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/module-type-aliases@npm:3.5.2-canary-6122"
@@ -3396,6 +3571,24 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: a620a8465437bd9f7bd0f0b3fd1ed9025cb62f7edc8b2bbd70adb35254e76b4d11cb456231aac1c2da7a17eb27ccc11d7241c67b610f48622c9c3fc265e9f49a
+  languageName: node
+  linkType: hard
+
+"@docusaurus/module-type-aliases@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/module-type-aliases@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@types/history": "npm:^4.7.11"
+    "@types/react": "npm:*"
+    "@types/react-router-config": "npm:*"
+    "@types/react-router-dom": "npm:*"
+    react-helmet-async: "npm:*"
+    react-loadable: "npm:@docusaurus/react-loadable@6.0.0"
+  peerDependencies:
+    react: "*"
+    react-dom: "*"
+  checksum: 59d78c699114dcd74e230b60da58d18fc201e942c802fd1e7a9439fe07423407f5a2df20a54764daf191b7855f712d1e160a136822844e35fe08d2f70b78bed1
   languageName: node
   linkType: hard
 
@@ -3429,6 +3622,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/plugin-content-blog@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-content-blog@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    cheerio: "npm:1.0.0-rc.12"
+    feed: "npm:^4.2.2"
+    fs-extra: "npm:^11.1.1"
+    lodash: "npm:^4.17.21"
+    reading-time: "npm:^1.5.0"
+    srcset: "npm:^4.0.0"
+    tslib: "npm:^2.6.0"
+    unist-util-visit: "npm:^5.0.0"
+    utility-types: "npm:^3.10.0"
+    webpack: "npm:^5.88.1"
+  peerDependencies:
+    "@docusaurus/plugin-content-docs": "*"
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 60ed280c3d76e11833bcb49d6ad892876ffdf829afd397fcfa64bab2e727fcfc44f9d860c5c91b07b0cd92761197c6e38014e1be579d248cb0e732d8453f8f18
+  languageName: node
+  linkType: hard
+
 "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6122"
@@ -3457,6 +3680,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/plugin-content-docs@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@types/react-router-config": "npm:^5.0.7"
+    combine-promises: "npm:^1.1.0"
+    fs-extra: "npm:^11.1.1"
+    js-yaml: "npm:^4.1.0"
+    lodash: "npm:^4.17.21"
+    tslib: "npm:^2.6.0"
+    utility-types: "npm:^3.10.0"
+    webpack: "npm:^5.88.1"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: a29247887608350f7d3be90c52c412a71b7ec1abb39f4c3efb9a47643db56eeb89e87efb098d1c3b2e00bb631bcbd278ab7af4303d70b2c54eee691d15d7187e
+  languageName: node
+  linkType: hard
+
 "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6122"
@@ -3473,6 +3724,25 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
   checksum: 1e83c933dcde860cfc05cc711d43ea2e172ac2c99b5bce7c6aa592b3481125c9f6a61e70f64f46c308ba8079e7b6273037760f74e2487e5916d675fd75919549
+  languageName: node
+  linkType: hard
+
+"@docusaurus/plugin-content-pages@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    fs-extra: "npm:^11.1.1"
+    tslib: "npm:^2.6.0"
+    webpack: "npm:^5.88.1"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 26118527e2425bc2d87bf5f8ad1040e6474e8c5c197beb92acbfa47fc5222afd9bf48b993cb0c581901a1b4839b999e0d64215f5945221d48a8f3d924b3d806b
   languageName: node
   linkType: hard
 
@@ -3620,6 +3890,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/theme-classic@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/theme-classic@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-translations": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@mdx-js/react": "npm:^3.0.0"
+    clsx: "npm:^2.0.0"
+    copy-text-to-clipboard: "npm:^3.2.0"
+    infima: "npm:0.2.0-alpha.45"
+    lodash: "npm:^4.17.21"
+    nprogress: "npm:^0.2.0"
+    postcss: "npm:^8.4.26"
+    prism-react-renderer: "npm:^2.3.0"
+    prismjs: "npm:^1.29.0"
+    react-router-dom: "npm:^5.3.4"
+    rtlcss: "npm:^4.1.0"
+    tslib: "npm:^2.6.0"
+    utility-types: "npm:^3.10.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: d31f2c9c0a5f26f66c5357569e933cac9e27f873f0334286045860c5da48c7cd4f99fd36d849f71a4da10626ba841658eb8d31fdd63fcb229e8dd6195254fff7
+  languageName: node
+  linkType: hard
+
 "@docusaurus/theme-common@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/theme-common@npm:3.5.2-canary-6122"
@@ -3641,6 +3948,30 @@ __metadata:
     react: ^18.0.0
     react-dom: ^18.0.0
   checksum: 325aff256705c3f9ed2fe20d67b34315eb16fe2a6944a2cf732007427fb0b912fad17a76451dc67a587ea0a91ea596d3c5927518732742a82677d8c10716b328
+  languageName: node
+  linkType: hard
+
+"@docusaurus/theme-common@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/theme-common@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@types/history": "npm:^4.7.11"
+    "@types/react": "npm:*"
+    "@types/react-router-config": "npm:*"
+    clsx: "npm:^2.0.0"
+    parse-numeric-range: "npm:^1.3.0"
+    prism-react-renderer: "npm:^2.3.0"
+    tslib: "npm:^2.6.0"
+    utility-types: "npm:^3.10.0"
+  peerDependencies:
+    "@docusaurus/plugin-content-docs": "*"
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: b486522a065065f3986f9ca7c53cd62d9b196bd532118ff36fee608898d181cf7bdd01dd26ffc29cf4b404378482a0615b911cbad6b98b727a9af25d0db469e7
   languageName: node
   linkType: hard
 
@@ -3681,6 +4012,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/theme-translations@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/theme-translations@npm:3.5.2-canary-6125"
+  dependencies:
+    fs-extra: "npm:^11.1.1"
+    tslib: "npm:^2.6.0"
+  checksum: 5ebe219e5cb5309982f3390d897253b4faaff14637a90cbb13549be88d26053e439c8c3c7594ab21c0e1cfd5f38c97bdb2052b7a96110055adfd9495526a2a42
+  languageName: node
+  linkType: hard
+
 "@docusaurus/types@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/types@npm:3.5.2-canary-6122"
@@ -3701,6 +4042,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/types@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/types@npm:3.5.2-canary-6125"
+  dependencies:
+    "@mdx-js/mdx": "npm:^3.0.0"
+    "@types/history": "npm:^4.7.11"
+    "@types/react": "npm:*"
+    commander: "npm:^5.1.0"
+    joi: "npm:^17.9.2"
+    react-helmet-async: "npm:^1.3.0"
+    utility-types: "npm:^3.10.0"
+    webpack: "npm:^5.95.0"
+    webpack-merge: "npm:^5.9.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: f130b11954290c80773566d3e7d9059f8d98b79f803f9977b0190f7e9cb615560e4c7c4a21fd8117d121180493984911de77cf34295cdd390751b53837efb8fe
+  languageName: node
+  linkType: hard
+
 "@docusaurus/utils-common@npm:3.5.2-canary-6122":
   version: 3.5.2-canary-6122
   resolution: "@docusaurus/utils-common@npm:3.5.2-canary-6122"
@@ -3712,6 +4073,20 @@ __metadata:
     "@docusaurus/types":
       optional: true
   checksum: 4f543882365b2600b2ea889a272f75c277e05514545b3de1027fa3e5902323bffaf6f36fa3f876c91102d4dced071fc6e3e22c2157116e07b7b0c070a8c4b413
+  languageName: node
+  linkType: hard
+
+"@docusaurus/utils-common@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/utils-common@npm:3.5.2-canary-6125"
+  dependencies:
+    tslib: "npm:^2.6.0"
+  peerDependencies:
+    "@docusaurus/types": "*"
+  peerDependenciesMeta:
+    "@docusaurus/types":
+      optional: true
+  checksum: 6ec7fc4199521f49e0e3028f49b1384d470315cd31c8577a019b10288ebdf9189bdc10729e7e7a90beb36a848e104c88c69bcc367b4e57720050f1912cbb8e40
   languageName: node
   linkType: hard
 
@@ -3728,6 +4103,22 @@ __metadata:
     lodash: "npm:^4.17.21"
     tslib: "npm:^2.6.0"
   checksum: 9771e37b7b326d29c969a0f0ce81625ebde8b705afd0f07582df12d2ee6a7e4bd777fc5bac3a2bb5c396d123834722bd094ebd78947e1ce32ba0c289692ffe23
+  languageName: node
+  linkType: hard
+
+"@docusaurus/utils-validation@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/utils-validation@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    fs-extra: "npm:^11.2.0"
+    joi: "npm:^17.9.2"
+    js-yaml: "npm:^4.1.0"
+    lodash: "npm:^4.17.21"
+    tslib: "npm:^2.6.0"
+  checksum: 8e56480f0a1a8e9d63e004676a33f5b532c84e20c31a96bd37b0b60a635a0c680dab8d5549088c132a7ea2005ca07c278656286647820504eacc61dcda93727a
   languageName: node
   linkType: hard
 
@@ -3761,6 +4152,39 @@ __metadata:
     "@docusaurus/types":
       optional: true
   checksum: 1bc66b704e102ae51da96cbfe7a72f0d21d19ee1f68395a6ebb293198a8f49012c609457d325e2fcc9d6dc44ac65e88674362c92739db29e0c00fc33bae543e5
+  languageName: node
+  linkType: hard
+
+"@docusaurus/utils@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/utils@npm:3.5.2-canary-6125"
+  dependencies:
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@svgr/webpack": "npm:^8.1.0"
+    escape-string-regexp: "npm:^4.0.0"
+    file-loader: "npm:^6.2.0"
+    fs-extra: "npm:^11.1.1"
+    github-slugger: "npm:^1.5.0"
+    globby: "npm:^11.1.0"
+    gray-matter: "npm:^4.0.3"
+    jiti: "npm:^1.20.0"
+    js-yaml: "npm:^4.1.0"
+    lodash: "npm:^4.17.21"
+    micromatch: "npm:^4.0.5"
+    prompts: "npm:^2.4.2"
+    resolve-pathname: "npm:^3.0.0"
+    shelljs: "npm:^0.8.5"
+    tslib: "npm:^2.6.0"
+    url-loader: "npm:^4.1.1"
+    utility-types: "npm:^3.10.0"
+    webpack: "npm:^5.88.1"
+  peerDependencies:
+    "@docusaurus/types": "*"
+  peerDependenciesMeta:
+    "@docusaurus/types":
+      optional: true
+  checksum: e86b2e6cf81546b9b4ebcc32220752afac3c8ba534b3f0023ea07cc41cd2a00969ddc731fb608f924c7111344f4764b29afd840a3dfdc323fc71676c0630441a
   languageName: node
   linkType: hard
 
@@ -7981,8 +8405,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docusaurus-plugin-redoc@workspace:packages/docusaurus-plugin-redoc"
   dependencies:
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
     "@redocly/openapi-core": "npm:1.16.0"
     core-js: "npm:^3.36.0"
     mobx: "npm:^6.12.4"
@@ -8001,10 +8425,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docusaurus-theme-redoc@workspace:packages/docusaurus-theme-redoc"
   dependencies:
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-classic": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-classic": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
     "@redocly/openapi-core": "npm:1.16.0"
     "@types/lodash": "npm:^4.14.200"
     "@types/postcss-prefix-selector": "npm:^1"
@@ -14967,8 +15391,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus@workspace:packages/redocusaurus"
   dependencies:
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     docusaurus-plugin-redoc: "npm:2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3250,7 +3250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.6.0":
+"@docusaurus/core@npm:3.6.0, @docusaurus/core@npm:^3.6.0":
   version: 3.6.0
   resolution: "@docusaurus/core@npm:3.6.0"
   dependencies:
@@ -3319,7 +3319,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/faster@npm:3.6.0":
+"@docusaurus/faster@npm:^3.6.0":
   version: 3.6.0
   resolution: "@docusaurus/faster@npm:3.6.0"
   dependencies:
@@ -3560,7 +3560,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:3.6.0":
+"@docusaurus/preset-classic@npm:^3.6.0":
   version: 3.6.0
   resolution: "@docusaurus/preset-classic@npm:3.6.0"
   dependencies:
@@ -14950,11 +14950,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus-website@workspace:website"
   dependencies:
-    "@docusaurus/core": "npm:3.6.0"
-    "@docusaurus/faster": "npm:3.6.0"
-    "@docusaurus/preset-classic": "npm:3.6.0"
-    "@docusaurus/theme-common": "npm:3.6.0"
-    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/core": "npm:^3.6.0"
+    "@docusaurus/faster": "npm:^3.6.0"
+    "@docusaurus/preset-classic": "npm:^3.6.0"
+    "@docusaurus/theme-common": "npm:^3.6.0"
+    "@docusaurus/utils": "npm:^3.6.0"
     "@percy/cli": "npm:^1.28.8"
     "@types/react": "npm:^18.3.3"
     clsx: "npm:^1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,29 +3189,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/babel@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/babel@npm:3.5.2-canary-6122"
-  dependencies:
-    "@babel/core": "npm:^7.25.9"
-    "@babel/generator": "npm:^7.25.9"
-    "@babel/plugin-syntax-dynamic-import": "npm:^7.8.3"
-    "@babel/plugin-transform-runtime": "npm:^7.25.9"
-    "@babel/preset-env": "npm:^7.25.9"
-    "@babel/preset-react": "npm:^7.25.9"
-    "@babel/preset-typescript": "npm:^7.25.9"
-    "@babel/runtime": "npm:^7.25.9"
-    "@babel/runtime-corejs3": "npm:^7.25.9"
-    "@babel/traverse": "npm:^7.25.9"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    babel-plugin-dynamic-import-node: "npm:^2.3.3"
-    fs-extra: "npm:^11.1.1"
-    tslib: "npm:^2.6.0"
-  checksum: 2e4acb9132e8fbcd7b97afc315baee6f75a3c8228348c5216abf007a604798a82f12ffdc00e987ab92786e85d14f462274d8296480b0cc8e694609f050c9c5a1
-  languageName: node
-  linkType: hard
-
 "@docusaurus/babel@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/babel@npm:3.5.2-canary-6125"
@@ -3232,44 +3209,6 @@ __metadata:
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
   checksum: 46c9fe01a06d1c67b47b4544584bcbe97221dd992035269d7e776978b1301ec65ac345f9461ef2213c1604f10c8e9d90aeadfbe2120d18ccf88231666b53795b
-  languageName: node
-  linkType: hard
-
-"@docusaurus/bundler@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/bundler@npm:3.5.2-canary-6122"
-  dependencies:
-    "@babel/core": "npm:^7.25.9"
-    "@docusaurus/babel": "npm:3.5.2-canary-6122"
-    "@docusaurus/cssnano-preset": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    autoprefixer: "npm:^10.4.14"
-    babel-loader: "npm:^9.2.1"
-    clean-css: "npm:^5.3.2"
-    copy-webpack-plugin: "npm:^11.0.0"
-    css-loader: "npm:^6.8.1"
-    css-minimizer-webpack-plugin: "npm:^5.0.1"
-    cssnano: "npm:^6.1.2"
-    file-loader: "npm:^6.2.0"
-    html-minifier-terser: "npm:^7.2.0"
-    mini-css-extract-plugin: "npm:^2.9.1"
-    null-loader: "npm:^4.0.1"
-    postcss: "npm:^8.4.26"
-    postcss-loader: "npm:^7.3.3"
-    react-dev-utils: "npm:^12.0.1"
-    terser-webpack-plugin: "npm:^5.3.9"
-    tslib: "npm:^2.6.0"
-    url-loader: "npm:^4.1.1"
-    webpack: "npm:^5.95.0"
-    webpackbar: "npm:^6.0.1"
-  peerDependencies:
-    "@docusaurus/faster": 3.5.2
-  peerDependenciesMeta:
-    "@docusaurus/faster":
-      optional: true
-  checksum: 8e089c79304330b5f6730f6af7317e7083ef6df29b40b4896c3e1c531b355addf0bc70adea35a69ffc1ddc5f3bd10f64594f887606712e54f2be161f57695077
   languageName: node
   linkType: hard
 
@@ -3308,63 +3247,6 @@ __metadata:
     "@docusaurus/faster":
       optional: true
   checksum: 54504a5becb64f327c668906b76177b9a1a7265b765f574648abf7182c52e6f5edc6d3eac830284820435b2dc7dc06dc307d02733edf9ba558a276be45e1090a
-  languageName: node
-  linkType: hard
-
-"@docusaurus/core@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/core@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/babel": "npm:3.5.2-canary-6122"
-    "@docusaurus/bundler": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
-    boxen: "npm:^6.2.1"
-    chalk: "npm:^4.1.2"
-    chokidar: "npm:^3.5.3"
-    cli-table3: "npm:^0.6.3"
-    combine-promises: "npm:^1.1.0"
-    commander: "npm:^5.1.0"
-    core-js: "npm:^3.31.1"
-    del: "npm:^6.1.1"
-    detect-port: "npm:^1.5.1"
-    escape-html: "npm:^1.0.3"
-    eta: "npm:^2.2.0"
-    eval: "npm:^0.1.8"
-    fs-extra: "npm:^11.1.1"
-    html-tags: "npm:^3.3.1"
-    html-webpack-plugin: "npm:^5.6.0"
-    leven: "npm:^3.1.0"
-    lodash: "npm:^4.17.21"
-    p-map: "npm:^4.0.0"
-    prompts: "npm:^2.4.2"
-    react-dev-utils: "npm:^12.0.1"
-    react-helmet-async: "npm:^1.3.0"
-    react-loadable: "npm:@docusaurus/react-loadable@6.0.0"
-    react-loadable-ssr-addon-v5-slorber: "npm:^1.0.1"
-    react-router: "npm:^5.3.4"
-    react-router-config: "npm:^5.1.1"
-    react-router-dom: "npm:^5.3.4"
-    rtl-detect: "npm:^1.0.4"
-    semver: "npm:^7.5.4"
-    serve-handler: "npm:^6.1.6"
-    shelljs: "npm:^0.8.5"
-    tslib: "npm:^2.6.0"
-    update-notifier: "npm:^6.0.2"
-    webpack: "npm:^5.95.0"
-    webpack-bundle-analyzer: "npm:^4.10.2"
-    webpack-dev-server: "npm:^4.15.2"
-    webpack-merge: "npm:^6.0.1"
-  peerDependencies:
-    "@mdx-js/react": ^3.0.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  bin:
-    docusaurus: bin/docusaurus.mjs
-  checksum: b778e9de54f2a2045c13a59c2211498d018240271a74e0e8918b296875f9db274cce20dbe1339d5cae6a00e29ffd1b60e279d1432ae5c31879fbaa99fb7dbb10
   languageName: node
   linkType: hard
 
@@ -3425,18 +3307,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/cssnano-preset@npm:3.5.2-canary-6122"
-  dependencies:
-    cssnano-preset-advanced: "npm:^6.1.2"
-    postcss: "npm:^8.4.38"
-    postcss-sort-media-queries: "npm:^5.2.0"
-    tslib: "npm:^2.6.0"
-  checksum: 8c22fa55aa8d4de56b0d5b5dbfd3b321728a178e36719384650bad6fd5975a20b285ce888479d83e6e82d7beb5c674981b5ecab0f5fbf307e27e9153c55df9e5
-  languageName: node
-  linkType: hard
-
 "@docusaurus/cssnano-preset@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/cssnano-preset@npm:3.5.2-canary-6125"
@@ -3449,9 +3319,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/faster@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/faster@npm:3.5.2-canary-6122"
+"@docusaurus/faster@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/faster@npm:3.5.2-canary-6125"
   dependencies:
     "@rspack/core": "npm:^1.0.14"
     "@swc/core": "npm:^1.7.39"
@@ -3459,20 +3329,11 @@ __metadata:
     browserslist: "npm:^4.24.2"
     lightningcss: "npm:^1.27.0"
     swc-loader: "npm:^0.2.6"
+    tslib: "npm:^2.6.0"
     webpack: "npm:^5.95.0"
   peerDependencies:
     "@docusaurus/types": "*"
-  checksum: 713b0aa617ceccfe95e847e800bee9ea1ad0d66d5267b849c39a13a717c7bdba8922bb6cc600ed07a9574c4a24bed87346d859e9eb52b321f632f19098f66c31
-  languageName: node
-  linkType: hard
-
-"@docusaurus/logger@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/logger@npm:3.5.2-canary-6122"
-  dependencies:
-    chalk: "npm:^4.1.2"
-    tslib: "npm:^2.6.0"
-  checksum: 0f3d84780ad5cd9b80bf36b2328f07eedd8ff592dd341151124616497fbf09495cb98418058f129e4e68b01f403b4c897f25f485be5add2feb22ee5e40841155
+  checksum: af4dd689fc1270bff0a162101a88976c1fce5aec6cf16918ef864a0d80855333f7939465575f57fae3bad461a1ac625952cc684e5615b8d33a9bb36b377ca796
   languageName: node
   linkType: hard
 
@@ -3483,41 +3344,6 @@ __metadata:
     chalk: "npm:^4.1.2"
     tslib: "npm:^2.6.0"
   checksum: ae844663c74f8d08bcca5a06ad8699f6e5e73c67b9b9c365ec6bd6eede027b035b9e9e7035b4615146319fd87ae042209754a75131530074d52fdc598f2f0f8b
-  languageName: node
-  linkType: hard
-
-"@docusaurus/mdx-loader@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/mdx-loader@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
-    "@mdx-js/mdx": "npm:^3.0.0"
-    "@slorber/remark-comment": "npm:^1.0.0"
-    escape-html: "npm:^1.0.3"
-    estree-util-value-to-estree: "npm:^3.0.1"
-    file-loader: "npm:^6.2.0"
-    fs-extra: "npm:^11.1.1"
-    image-size: "npm:^1.0.2"
-    mdast-util-mdx: "npm:^3.0.0"
-    mdast-util-to-string: "npm:^4.0.0"
-    rehype-raw: "npm:^7.0.0"
-    remark-directive: "npm:^3.0.0"
-    remark-emoji: "npm:^4.0.0"
-    remark-frontmatter: "npm:^5.0.0"
-    remark-gfm: "npm:^4.0.0"
-    stringify-object: "npm:^3.3.0"
-    tslib: "npm:^2.6.0"
-    unified: "npm:^11.0.3"
-    unist-util-visit: "npm:^5.0.0"
-    url-loader: "npm:^4.1.1"
-    vfile: "npm:^6.0.1"
-    webpack: "npm:^5.88.1"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 8bf6f0b1c7f8fac9b798e8a4040062ca7b8a539058e7b5cd9370b149369b832d97354dec661fe59f5856e4270722b785adb83ec74356d86ac9e187345c0a7173
   languageName: node
   linkType: hard
 
@@ -3556,24 +3382,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/module-type-aliases@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-    "@types/react-router-config": "npm:*"
-    "@types/react-router-dom": "npm:*"
-    react-helmet-async: "npm:*"
-    react-loadable: "npm:@docusaurus/react-loadable@6.0.0"
-  peerDependencies:
-    react: "*"
-    react-dom: "*"
-  checksum: a620a8465437bd9f7bd0f0b3fd1ed9025cb62f7edc8b2bbd70adb35254e76b4d11cb456231aac1c2da7a17eb27ccc11d7241c67b610f48622c9c3fc265e9f49a
-  languageName: node
-  linkType: hard
-
 "@docusaurus/module-type-aliases@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/module-type-aliases@npm:3.5.2-canary-6125"
@@ -3589,36 +3397,6 @@ __metadata:
     react: "*"
     react-dom: "*"
   checksum: 59d78c699114dcd74e230b60da58d18fc201e942c802fd1e7a9439fe07423407f5a2df20a54764daf191b7855f712d1e160a136822844e35fe08d2f70b78bed1
-  languageName: node
-  linkType: hard
-
-"@docusaurus/plugin-content-blog@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-content-blog@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
-    cheerio: "npm:1.0.0-rc.12"
-    feed: "npm:^4.2.2"
-    fs-extra: "npm:^11.1.1"
-    lodash: "npm:^4.17.21"
-    reading-time: "npm:^1.5.0"
-    srcset: "npm:^4.0.0"
-    tslib: "npm:^2.6.0"
-    unist-util-visit: "npm:^5.0.0"
-    utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.88.1"
-  peerDependencies:
-    "@docusaurus/plugin-content-docs": "*"
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 8f7634a09cd5a1aca3870cd9ee5e3ee7c89e76e3f9820dae04ca05cad847eabdfb1b690eb6e2d26871f5eda864c593ea125963cea1bef9f0224c4bcdd8e52ce2
   languageName: node
   linkType: hard
 
@@ -3652,34 +3430,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
-    "@types/react-router-config": "npm:^5.0.7"
-    combine-promises: "npm:^1.1.0"
-    fs-extra: "npm:^11.1.1"
-    js-yaml: "npm:^4.1.0"
-    lodash: "npm:^4.17.21"
-    tslib: "npm:^2.6.0"
-    utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.88.1"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 3e8ccc94b3de16ac02fd8f84eeb4e3dd360a51086f01e9cacf566104f4d969627ba84755d36323da40093f8402cd91067e14f61ec5237967496fa8b7e4e8b136
-  languageName: node
-  linkType: hard
-
 "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6125"
@@ -3708,25 +3458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
-    fs-extra: "npm:^11.1.1"
-    tslib: "npm:^2.6.0"
-    webpack: "npm:^5.88.1"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 1e83c933dcde860cfc05cc711d43ea2e172ac2c99b5bce7c6aa592b3481125c9f6a61e70f64f46c308ba8079e7b6273037760f74e2487e5916d675fd75919549
-  languageName: node
-  linkType: hard
-
 "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6125"
@@ -3746,147 +3477,110 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-debug@npm:3.5.2-canary-6122"
+"@docusaurus/plugin-debug@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-debug@npm:3.5.2-canary-6125"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
     fs-extra: "npm:^11.1.1"
     react-json-view-lite: "npm:^1.2.0"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: d3c26f25f117e145f6dc0d6ee981d8f6e044a80254b5dd7b0d9b8154ea3936147e0e47358c219d2bf5795784e752aeb10d0a634eaa98e557b84362608a388207
+  checksum: 9dd2ac24020df5a3f000022f382cc178376fb9bd4c8fcf5f07062033a47bfa646ad4295b387681fcebff87729c76fa03fca3dceb0ab9089f52c1f59b56e33eea
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6122"
+"@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6125"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 94d03d46caaa2927f334bc5ca0d60b6e9cfe4d27796b98c33abe219ab360d374ffd01e2c1853125ef5a799a463459c0bcc1e25296f158db83e6c401e5a02af5c
+  checksum: 67bc5183ea129f9682032a5bd1e3315902a7d6d23a28eee7697610727127890a0a30c0e91c050baa83324a3611159cdaf2d89c45650c0b0a1d132898a3467fd8
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6122"
+"@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6125"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
     "@types/gtag.js": "npm:^0.0.12"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 56cc61410d6e61cf5198fa5f3c6638a95891aabce2318a1cc355f2c67156d09686bafaa9aef6be6703f8e229825ff92d0d8d27e4f6d42902107a11d55d9d9613
+  checksum: d484ce1528852abb52e2fae7f8b886a31890994bb684382019df452aa49479a7c4cd8ea11f99a0f8256a38b1727a84cfac7b3d4306446c631a3d92d51fb48735
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6122"
+"@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6125"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 1e41d1e7d07eececede6377d0cb4ff2003e57df84a9a5f99aa07d3abad02ead0dd9f03fb5a5397539c88b78892023e055b88e16475febc9ba5d835c6c4024a85
+  checksum: c38e3ed483ed2bf2633a8bc904c9b534219925037201089aefaea0fdf18d93d070e545d56007c322f7e74419fb6fc197c5cae69c4a8636d066046dd18a45db00
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/plugin-sitemap@npm:3.5.2-canary-6122"
+"@docusaurus/plugin-sitemap@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/plugin-sitemap@npm:3.5.2-canary-6125"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
     fs-extra: "npm:^11.1.1"
     sitemap: "npm:^7.1.1"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 20a4ab4c1e997dba108bc4053e0866f9f526700d5a55280f880a095697f6ef04a1c37bcfb8a3da1be49ccf6f13b04a10caaf779fed6b430f2184de0c1b19bfb7
+  checksum: b05372d675f085f2606278954e800fb6d9c5a9d8bfb6f13d60da76e486b8709c1e8942770afdffd81e923cb5260faebc5c0119191705d2dbcfd0066304e44e29
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/preset-classic@npm:3.5.2-canary-6122"
+"@docusaurus/preset-classic@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/preset-classic@npm:3.5.2-canary-6125"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-debug": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-google-analytics": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-google-gtag": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-google-tag-manager": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-sitemap": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-classic": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-search-algolia": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-debug": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-google-analytics": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-google-gtag": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-google-tag-manager": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-sitemap": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-classic": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-search-algolia": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.5.2-canary-6125"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 6d002daffb30497334d4209ca18d49c56c8ade6b047d4b78f061e3357adf244bd4b02d1a6f021e5b414cc8889eafc5b8f3255da0baece55f5dd122be64be9848
-  languageName: node
-  linkType: hard
-
-"@docusaurus/theme-classic@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/theme-classic@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-translations": "npm:3.5.2-canary-6122"
-    "@docusaurus/types": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
-    "@mdx-js/react": "npm:^3.0.0"
-    clsx: "npm:^2.0.0"
-    copy-text-to-clipboard: "npm:^3.2.0"
-    infima: "npm:0.2.0-alpha.45"
-    lodash: "npm:^4.17.21"
-    nprogress: "npm:^0.2.0"
-    postcss: "npm:^8.4.26"
-    prism-react-renderer: "npm:^2.3.0"
-    prismjs: "npm:^1.29.0"
-    react-router-dom: "npm:^5.3.4"
-    rtlcss: "npm:^4.1.0"
-    tslib: "npm:^2.6.0"
-    utility-types: "npm:^3.10.0"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: dea6b7a74fbded73a98f524501da677b103445327b8ef6b5fc8dfa1af13ea85d23fe1d174139acc9877e063d4baa93250c05ad0f4df8e986c87fffa6c75e209b
+  checksum: be51a823ed6f1494e7c5c9d9f8239524536c41a52e5f11d586162a47adc7b4ea6511d94aa1a232a6268d79c577654d68ffedd12fd94e39f155e28da84962869e
   languageName: node
   linkType: hard
 
@@ -3927,30 +3621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/theme-common@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6122"
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-    "@types/react-router-config": "npm:*"
-    clsx: "npm:^2.0.0"
-    parse-numeric-range: "npm:^1.3.0"
-    prism-react-renderer: "npm:^2.3.0"
-    tslib: "npm:^2.6.0"
-    utility-types: "npm:^3.10.0"
-  peerDependencies:
-    "@docusaurus/plugin-content-docs": "*"
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 325aff256705c3f9ed2fe20d67b34315eb16fe2a6944a2cf732007427fb0b912fad17a76451dc67a587ea0a91ea596d3c5927518732742a82677d8c10716b328
-  languageName: node
-  linkType: hard
-
 "@docusaurus/theme-common@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/theme-common@npm:3.5.2-canary-6125"
@@ -3975,18 +3645,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/theme-search-algolia@npm:3.5.2-canary-6122"
+"@docusaurus/theme-search-algolia@npm:3.5.2-canary-6125":
+  version: 3.5.2-canary-6125
+  resolution: "@docusaurus/theme-search-algolia@npm:3.5.2-canary-6125"
   dependencies:
     "@docsearch/react": "npm:^3.5.2"
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-translations": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.5.2-canary-6125"
+    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-translations": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
     algoliasearch: "npm:^4.18.0"
     algoliasearch-helper: "npm:^3.13.3"
     clsx: "npm:^2.0.0"
@@ -3998,17 +3668,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 8a2b5862bfc83354ffaed84a7d1e768730a7c1d004c1c1f5955a312bce061c2b1c22e9e4be202165025f737964f5bff1150ca75f0c7f64e0ae7dcdf90e6f5274
-  languageName: node
-  linkType: hard
-
-"@docusaurus/theme-translations@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/theme-translations@npm:3.5.2-canary-6122"
-  dependencies:
-    fs-extra: "npm:^11.1.1"
-    tslib: "npm:^2.6.0"
-  checksum: 667899feb1ebd48ba984cf04e8109a1ba1c0cfb629f5325f8708bc63a74ec864837c4131bfc0e6e5e5137189141ed2a6881f5140e4a417f9a1afca47ba299a42
+  checksum: e3110c85e6ba4d868a6fe0ee83693c83d07217996dcc6e894547ccf2cb5963794bedd5e9249b75c46044d5483a10722d3e74e5557c13b70211e8bbaf00220ef2
   languageName: node
   linkType: hard
 
@@ -4019,26 +3679,6 @@ __metadata:
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
   checksum: 5ebe219e5cb5309982f3390d897253b4faaff14637a90cbb13549be88d26053e439c8c3c7594ab21c0e1cfd5f38c97bdb2052b7a96110055adfd9495526a2a42
-  languageName: node
-  linkType: hard
-
-"@docusaurus/types@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/types@npm:3.5.2-canary-6122"
-  dependencies:
-    "@mdx-js/mdx": "npm:^3.0.0"
-    "@types/history": "npm:^4.7.11"
-    "@types/react": "npm:*"
-    commander: "npm:^5.1.0"
-    joi: "npm:^17.9.2"
-    react-helmet-async: "npm:^1.3.0"
-    utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.95.0"
-    webpack-merge: "npm:^5.9.0"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 0c18308e2bf3f3865435c697539cd928b47208b3992c29c07a650d74394ef88265099fcc52f457acac4fbeb8b69cec4a9d5a5b0bb12786d56f55751ab12a46b7
   languageName: node
   linkType: hard
 
@@ -4062,20 +3702,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/utils-common@npm:3.5.2-canary-6122"
-  dependencies:
-    tslib: "npm:^2.6.0"
-  peerDependencies:
-    "@docusaurus/types": "*"
-  peerDependenciesMeta:
-    "@docusaurus/types":
-      optional: true
-  checksum: 4f543882365b2600b2ea889a272f75c277e05514545b3de1027fa3e5902323bffaf6f36fa3f876c91102d4dced071fc6e3e22c2157116e07b7b0c070a8c4b413
-  languageName: node
-  linkType: hard
-
 "@docusaurus/utils-common@npm:3.5.2-canary-6125":
   version: 3.5.2-canary-6125
   resolution: "@docusaurus/utils-common@npm:3.5.2-canary-6125"
@@ -4087,22 +3713,6 @@ __metadata:
     "@docusaurus/types":
       optional: true
   checksum: 6ec7fc4199521f49e0e3028f49b1384d470315cd31c8577a019b10288ebdf9189bdc10729e7e7a90beb36a848e104c88c69bcc367b4e57720050f1912cbb8e40
-  languageName: node
-  linkType: hard
-
-"@docusaurus/utils-validation@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/utils-validation@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    fs-extra: "npm:^11.2.0"
-    joi: "npm:^17.9.2"
-    js-yaml: "npm:^4.1.0"
-    lodash: "npm:^4.17.21"
-    tslib: "npm:^2.6.0"
-  checksum: 9771e37b7b326d29c969a0f0ce81625ebde8b705afd0f07582df12d2ee6a7e4bd777fc5bac3a2bb5c396d123834722bd094ebd78947e1ce32ba0c289692ffe23
   languageName: node
   linkType: hard
 
@@ -4119,39 +3729,6 @@ __metadata:
     lodash: "npm:^4.17.21"
     tslib: "npm:^2.6.0"
   checksum: 8e56480f0a1a8e9d63e004676a33f5b532c84e20c31a96bd37b0b60a635a0c680dab8d5549088c132a7ea2005ca07c278656286647820504eacc61dcda93727a
-  languageName: node
-  linkType: hard
-
-"@docusaurus/utils@npm:3.5.2-canary-6122":
-  version: 3.5.2-canary-6122
-  resolution: "@docusaurus/utils@npm:3.5.2-canary-6122"
-  dependencies:
-    "@docusaurus/logger": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6122"
-    "@svgr/webpack": "npm:^8.1.0"
-    escape-string-regexp: "npm:^4.0.0"
-    file-loader: "npm:^6.2.0"
-    fs-extra: "npm:^11.1.1"
-    github-slugger: "npm:^1.5.0"
-    globby: "npm:^11.1.0"
-    gray-matter: "npm:^4.0.3"
-    jiti: "npm:^1.20.0"
-    js-yaml: "npm:^4.1.0"
-    lodash: "npm:^4.17.21"
-    micromatch: "npm:^4.0.5"
-    prompts: "npm:^2.4.2"
-    resolve-pathname: "npm:^3.0.0"
-    shelljs: "npm:^0.8.5"
-    tslib: "npm:^2.6.0"
-    url-loader: "npm:^4.1.1"
-    utility-types: "npm:^3.10.0"
-    webpack: "npm:^5.88.1"
-  peerDependencies:
-    "@docusaurus/types": "*"
-  peerDependenciesMeta:
-    "@docusaurus/types":
-      optional: true
-  checksum: 1bc66b704e102ae51da96cbfe7a72f0d21d19ee1f68395a6ebb293198a8f49012c609457d325e2fcc9d6dc44ac65e88674362c92739db29e0c00fc33bae543e5
   languageName: node
   linkType: hard
 
@@ -15373,11 +14950,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus-website@workspace:website"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6122"
-    "@docusaurus/faster": "npm:3.5.2-canary-6122"
-    "@docusaurus/preset-classic": "npm:3.5.2-canary-6122"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6122"
-    "@docusaurus/utils": "npm:3.5.2-canary-6122"
+    "@docusaurus/core": "npm:3.5.2-canary-6125"
+    "@docusaurus/faster": "npm:3.5.2-canary-6125"
+    "@docusaurus/preset-classic": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/utils": "npm:3.5.2-canary-6125"
     "@percy/cli": "npm:^1.28.8"
     "@types/react": "npm:^18.3.3"
     clsx: "npm:^1.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3189,9 +3189,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/babel@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/babel@npm:3.5.2-canary-6125"
+"@docusaurus/babel@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/babel@npm:3.6.0"
   dependencies:
     "@babel/core": "npm:^7.25.9"
     "@babel/generator": "npm:^7.25.9"
@@ -3203,25 +3203,25 @@ __metadata:
     "@babel/runtime": "npm:^7.25.9"
     "@babel/runtime-corejs3": "npm:^7.25.9"
     "@babel/traverse": "npm:^7.25.9"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
     babel-plugin-dynamic-import-node: "npm:^2.3.3"
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
-  checksum: 46c9fe01a06d1c67b47b4544584bcbe97221dd992035269d7e776978b1301ec65ac345f9461ef2213c1604f10c8e9d90aeadfbe2120d18ccf88231666b53795b
+  checksum: a519b7dc31d9c7bd24d2ea371f803240d1f9526aee4a2c01477fd95f4626965f919bc762ffc2bdac70aafd86569433b450e7e3487578e7cfc2fa82cd57acb69c
   languageName: node
   linkType: hard
 
-"@docusaurus/bundler@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/bundler@npm:3.5.2-canary-6125"
+"@docusaurus/bundler@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/bundler@npm:3.6.0"
   dependencies:
     "@babel/core": "npm:^7.25.9"
-    "@docusaurus/babel": "npm:3.5.2-canary-6125"
-    "@docusaurus/cssnano-preset": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/babel": "npm:3.6.0"
+    "@docusaurus/cssnano-preset": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
     autoprefixer: "npm:^10.4.14"
     babel-loader: "npm:^9.2.1"
     clean-css: "npm:^5.3.2"
@@ -3246,21 +3246,21 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/faster":
       optional: true
-  checksum: 54504a5becb64f327c668906b76177b9a1a7265b765f574648abf7182c52e6f5edc6d3eac830284820435b2dc7dc06dc307d02733edf9ba558a276be45e1090a
+  checksum: d2c8614a8f6dce362e2df5781ecd365519d9eeb951dee98c8644462c5f99772a86d0939ff6b25f89e380fedab4c74c18e08e8be3279345a28679e5dd0a424697
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/core@npm:3.5.2-canary-6125"
+"@docusaurus/core@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/core@npm:3.6.0"
   dependencies:
-    "@docusaurus/babel": "npm:3.5.2-canary-6125"
-    "@docusaurus/bundler": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/babel": "npm:3.6.0"
+    "@docusaurus/bundler": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/mdx-loader": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     boxen: "npm:^6.2.1"
     chalk: "npm:^4.1.2"
     chokidar: "npm:^3.5.3"
@@ -3303,25 +3303,25 @@ __metadata:
     react-dom: ^18.0.0
   bin:
     docusaurus: bin/docusaurus.mjs
-  checksum: 146fb5376cf61f36092d7662095db4197ce4f6acce42c7fdf14f3ccd0ceed11143b179197bd587e06aebcd882af473a2fdf350b1da7acc79fe413c3d8c3819c3
+  checksum: d0249570053484f53003d6d5376576c609ccb8472001401d332446601a2f46352cce70b943337dec6049ab0522d46f83f8a0edbc1763ce4c5bdc41e44db44b8d
   languageName: node
   linkType: hard
 
-"@docusaurus/cssnano-preset@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/cssnano-preset@npm:3.5.2-canary-6125"
+"@docusaurus/cssnano-preset@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/cssnano-preset@npm:3.6.0"
   dependencies:
     cssnano-preset-advanced: "npm:^6.1.2"
     postcss: "npm:^8.4.38"
     postcss-sort-media-queries: "npm:^5.2.0"
     tslib: "npm:^2.6.0"
-  checksum: ba04013e7ec5b67a3e3e3d117fd37740f05deb9e488d8d2b48d2223a6ea7f9daf8af2670ef93bbf4b7a142eb4dbdaad2d401ad6f40c2720f97302b606498629c
+  checksum: 957c646df1b8593292d667e1b5e4abdce8d3bef484050885a88533560dffb778dafbb355c1a7fc30c4fe0f2be0321c518eb00e982db10ca1db067692c523f1be
   languageName: node
   linkType: hard
 
-"@docusaurus/faster@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/faster@npm:3.5.2-canary-6125"
+"@docusaurus/faster@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/faster@npm:3.6.0"
   dependencies:
     "@rspack/core": "npm:^1.0.14"
     "@swc/core": "npm:^1.7.39"
@@ -3333,27 +3333,27 @@ __metadata:
     webpack: "npm:^5.95.0"
   peerDependencies:
     "@docusaurus/types": "*"
-  checksum: af4dd689fc1270bff0a162101a88976c1fce5aec6cf16918ef864a0d80855333f7939465575f57fae3bad461a1ac625952cc684e5615b8d33a9bb36b377ca796
+  checksum: eedf4ba04f43b2cc8e10d9f3b1b6c6254cafad64d76456361adfe7c14641a6d43fb24c41fe853b59e5bfe55131807d95f05b6e17e575958bdc6575f1e0d794a5
   languageName: node
   linkType: hard
 
-"@docusaurus/logger@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/logger@npm:3.5.2-canary-6125"
+"@docusaurus/logger@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/logger@npm:3.6.0"
   dependencies:
     chalk: "npm:^4.1.2"
     tslib: "npm:^2.6.0"
-  checksum: ae844663c74f8d08bcca5a06ad8699f6e5e73c67b9b9c365ec6bd6eede027b035b9e9e7035b4615146319fd87ae042209754a75131530074d52fdc598f2f0f8b
+  checksum: da4b49ab1d8f77102feff76b65fead97189c76548929333d07a31ffae0317726aba9b72aa5a92ccee1b1c3d2383a8cd3396d5a41ebbe3dc8a85e45a985c7ea6c
   languageName: node
   linkType: hard
 
-"@docusaurus/mdx-loader@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/mdx-loader@npm:3.5.2-canary-6125"
+"@docusaurus/mdx-loader@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/mdx-loader@npm:3.6.0"
   dependencies:
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     "@mdx-js/mdx": "npm:^3.0.0"
     "@slorber/remark-comment": "npm:^1.0.0"
     escape-html: "npm:^1.0.3"
@@ -3378,15 +3378,15 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 62f5d40ed9dc1ab8cc7e9590b333d701b64f95b1b37e963f0f3dfe9a36607ae55087482fa0dd53aaff23f518a4df150b083fb22e70e695a1ac4ac41464d54951
+  checksum: 036179af8903d99e43701ed34f98463dc6307d75d2fec58aa415ba15ce3c899ea9ac21099a6552a75f337d2587e5aa7aab9c9db5a3f32457ff7ef7e6c3fc8bf2
   languageName: node
   linkType: hard
 
-"@docusaurus/module-type-aliases@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/module-type-aliases@npm:3.5.2-canary-6125"
+"@docusaurus/module-type-aliases@npm:3.6.0, @docusaurus/module-type-aliases@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/module-type-aliases@npm:3.6.0"
   dependencies:
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:3.6.0"
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
     "@types/react-router-config": "npm:*"
@@ -3396,22 +3396,22 @@ __metadata:
   peerDependencies:
     react: "*"
     react-dom: "*"
-  checksum: 59d78c699114dcd74e230b60da58d18fc201e942c802fd1e7a9439fe07423407f5a2df20a54764daf191b7855f712d1e160a136822844e35fe08d2f70b78bed1
+  checksum: cd99b8cf5a427fc025e909acf016a19e2e2e33ddc7a350aa6aa6205696cd1fff3fb3b91a6e86423e01f3283594a50e32cce6a88595f5dede5043e41af786de37
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-blog@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-content-blog@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-content-blog@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-content-blog@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/mdx-loader": "npm:3.6.0"
+    "@docusaurus/theme-common": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     cheerio: "npm:1.0.0-rc.12"
     feed: "npm:^4.2.2"
     fs-extra: "npm:^11.1.1"
@@ -3426,23 +3426,23 @@ __metadata:
     "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 60ed280c3d76e11833bcb49d6ad892876ffdf829afd397fcfa64bab2e727fcfc44f9d860c5c91b07b0cd92761197c6e38014e1be579d248cb0e732d8453f8f18
+  checksum: a6d04d7e993c590e26557e4359016b7334763f3c34532619273c5eca776fc450e57f94cd6eeb6f80b7167086caf8c989b13912842137c5adb0979d3ab7e53548
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-docs@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-content-docs@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-content-docs@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-content-docs@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/mdx-loader": "npm:3.6.0"
+    "@docusaurus/module-type-aliases": "npm:3.6.0"
+    "@docusaurus/theme-common": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     "@types/react-router-config": "npm:^5.0.7"
     combine-promises: "npm:^1.1.0"
     fs-extra: "npm:^11.1.1"
@@ -3454,153 +3454,153 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: a29247887608350f7d3be90c52c412a71b7ec1abb39f4c3efb9a47643db56eeb89e87efb098d1c3b2e00bb631bcbd278ab7af4303d70b2c54eee691d15d7187e
+  checksum: f4ea473b43e9865182ad4bdd4da1de9500481e6910fa1ec054ef11f68fef15477ede15c9f8fc47f4ce04d94ba4b9d54b72b93326ba255cf25e34be77ac229f46
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-content-pages@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-content-pages@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-content-pages@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-content-pages@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/mdx-loader": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
     webpack: "npm:^5.88.1"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 26118527e2425bc2d87bf5f8ad1040e6474e8c5c197beb92acbfa47fc5222afd9bf48b993cb0c581901a1b4839b999e0d64215f5945221d48a8f3d924b3d806b
+  checksum: 9c21df84384a515a9ac583109cda8b172fbd042ca42a7a0d066396a359029033d6a75181b46b3f38539f43378b93c2be973a7d9c6aa9183b5dac74c806b7b30e
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-debug@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-debug@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-debug@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-debug@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
     fs-extra: "npm:^11.1.1"
     react-json-view-lite: "npm:^1.2.0"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 9dd2ac24020df5a3f000022f382cc178376fb9bd4c8fcf5f07062033a47bfa646ad4295b387681fcebff87729c76fa03fca3dceb0ab9089f52c1f59b56e33eea
+  checksum: d0bb5a7fbf1594d540512a5e9b0f588dc1d4d5190b98f93a861437126ccf2a274e09d6aa4080906637a8401c85f8c2d018bd00fa2707f3d7d307e5769b2f5fba
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-google-analytics@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-google-analytics@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-google-analytics@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 67bc5183ea129f9682032a5bd1e3315902a7d6d23a28eee7697610727127890a0a30c0e91c050baa83324a3611159cdaf2d89c45650c0b0a1d132898a3467fd8
+  checksum: aa9c96099723be7454d6209973ebe14265c6e35c99d8231568c5c5ee47fc6c6ab11c826522ce0356fd52012acb11eae00df520ddb41504d8b02a0031f28b98f0
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-google-gtag@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-google-gtag@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-google-gtag@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     "@types/gtag.js": "npm:^0.0.12"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: d484ce1528852abb52e2fae7f8b886a31890994bb684382019df452aa49479a7c4cd8ea11f99a0f8256a38b1727a84cfac7b3d4306446c631a3d92d51fb48735
+  checksum: 300bdc62ab115caef46498cc9c376ef4c79e48c1c0cc1f31c0c22ba54823801e1143d6e7447103815333bf47eacb3bf34baa1d3e809645ec233f3e743e8f2b1f
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-google-tag-manager@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-google-tag-manager@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: c38e3ed483ed2bf2633a8bc904c9b534219925037201089aefaea0fdf18d93d070e545d56007c322f7e74419fb6fc197c5cae69c4a8636d066046dd18a45db00
+  checksum: 37546382bf6edf17490b4d7a416e7c00cf3f09c591a402ba3d5519fe3c97bbfe54bc039964d0878677570fca82105b4e44ca8c80c29d6e43d94342568bdb865d
   languageName: node
   linkType: hard
 
-"@docusaurus/plugin-sitemap@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/plugin-sitemap@npm:3.5.2-canary-6125"
+"@docusaurus/plugin-sitemap@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/plugin-sitemap@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     fs-extra: "npm:^11.1.1"
     sitemap: "npm:^7.1.1"
     tslib: "npm:^2.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: b05372d675f085f2606278954e800fb6d9c5a9d8bfb6f13d60da76e486b8709c1e8942770afdffd81e923cb5260faebc5c0119191705d2dbcfd0066304e44e29
+  checksum: 8e03e852e006b52137141f53f603f5197b2164e09cea27a4505c9b5ce5f94dc7689652edd476ae6b91f56b18e3701744e3528e2cc8e1c8f765504f79953dd754
   languageName: node
   linkType: hard
 
-"@docusaurus/preset-classic@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/preset-classic@npm:3.5.2-canary-6125"
+"@docusaurus/preset-classic@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/preset-classic@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-debug": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-google-analytics": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-google-gtag": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-google-tag-manager": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-sitemap": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-classic": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-search-algolia": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/plugin-content-blog": "npm:3.6.0"
+    "@docusaurus/plugin-content-docs": "npm:3.6.0"
+    "@docusaurus/plugin-content-pages": "npm:3.6.0"
+    "@docusaurus/plugin-debug": "npm:3.6.0"
+    "@docusaurus/plugin-google-analytics": "npm:3.6.0"
+    "@docusaurus/plugin-google-gtag": "npm:3.6.0"
+    "@docusaurus/plugin-google-tag-manager": "npm:3.6.0"
+    "@docusaurus/plugin-sitemap": "npm:3.6.0"
+    "@docusaurus/theme-classic": "npm:3.6.0"
+    "@docusaurus/theme-common": "npm:3.6.0"
+    "@docusaurus/theme-search-algolia": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: be51a823ed6f1494e7c5c9d9f8239524536c41a52e5f11d586162a47adc7b4ea6511d94aa1a232a6268d79c577654d68ffedd12fd94e39f155e28da84962869e
+  checksum: f32c335c2cec0f3a906aa8cb3fa97e6c1c5a2998a1926cc0b17f3de8ab5f1ad67bd938cce4d1884a32b46fa4f0191568b84511685c546bb3752ceef5be42142a
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-classic@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/theme-classic@npm:3.5.2-canary-6125"
+"@docusaurus/theme-classic@npm:3.6.0, @docusaurus/theme-classic@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/theme-classic@npm:3.6.0"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-blog": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-pages": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-translations": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/mdx-loader": "npm:3.6.0"
+    "@docusaurus/module-type-aliases": "npm:3.6.0"
+    "@docusaurus/plugin-content-blog": "npm:3.6.0"
+    "@docusaurus/plugin-content-docs": "npm:3.6.0"
+    "@docusaurus/plugin-content-pages": "npm:3.6.0"
+    "@docusaurus/theme-common": "npm:3.6.0"
+    "@docusaurus/theme-translations": "npm:3.6.0"
+    "@docusaurus/types": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     "@mdx-js/react": "npm:^3.0.0"
     clsx: "npm:^2.0.0"
     copy-text-to-clipboard: "npm:^3.2.0"
@@ -3617,18 +3617,18 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: d31f2c9c0a5f26f66c5357569e933cac9e27f873f0334286045860c5da48c7cd4f99fd36d849f71a4da10626ba841658eb8d31fdd63fcb229e8dd6195254fff7
+  checksum: d8761e27c7fbdab1a6c842da162b7289ec5c8490e95f0cb6b5637abde4b5ee4d3a9f43da48dc9a0508d7f9c10a25ff041b4d820dd4b3698aa6d990141b580b1e
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-common@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/theme-common@npm:3.5.2-canary-6125"
+"@docusaurus/theme-common@npm:3.6.0, @docusaurus/theme-common@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/theme-common@npm:3.6.0"
   dependencies:
-    "@docusaurus/mdx-loader": "npm:3.5.2-canary-6125"
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/mdx-loader": "npm:3.6.0"
+    "@docusaurus/module-type-aliases": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
     "@types/history": "npm:^4.7.11"
     "@types/react": "npm:*"
     "@types/react-router-config": "npm:*"
@@ -3641,22 +3641,22 @@ __metadata:
     "@docusaurus/plugin-content-docs": "*"
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: b486522a065065f3986f9ca7c53cd62d9b196bd532118ff36fee608898d181cf7bdd01dd26ffc29cf4b404378482a0615b911cbad6b98b727a9af25d0db469e7
+  checksum: bcb6c612f2ed6221ab952adb520e5d05f13343ab9feb696dca67ced908f676ae34176460aab70196582adb835aba0246e0626a6439109bf47edb5f138510aab2
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-search-algolia@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/theme-search-algolia@npm:3.5.2-canary-6125"
+"@docusaurus/theme-search-algolia@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/theme-search-algolia@npm:3.6.0"
   dependencies:
     "@docsearch/react": "npm:^3.5.2"
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/plugin-content-docs": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-translations": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-validation": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/plugin-content-docs": "npm:3.6.0"
+    "@docusaurus/theme-common": "npm:3.6.0"
+    "@docusaurus/theme-translations": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-validation": "npm:3.6.0"
     algoliasearch: "npm:^4.18.0"
     algoliasearch-helper: "npm:^3.13.3"
     clsx: "npm:^2.0.0"
@@ -3668,23 +3668,23 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: e3110c85e6ba4d868a6fe0ee83693c83d07217996dcc6e894547ccf2cb5963794bedd5e9249b75c46044d5483a10722d3e74e5557c13b70211e8bbaf00220ef2
+  checksum: 29090117d934493a7579a272bc604adda9ef6e1215b36a76941924ccf63b4ab0db895395e59fe210061bbf8a79d0b3cfcb1b2320cbd45cfd163be4e412a6798c
   languageName: node
   linkType: hard
 
-"@docusaurus/theme-translations@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/theme-translations@npm:3.5.2-canary-6125"
+"@docusaurus/theme-translations@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/theme-translations@npm:3.6.0"
   dependencies:
     fs-extra: "npm:^11.1.1"
     tslib: "npm:^2.6.0"
-  checksum: 5ebe219e5cb5309982f3390d897253b4faaff14637a90cbb13549be88d26053e439c8c3c7594ab21c0e1cfd5f38c97bdb2052b7a96110055adfd9495526a2a42
+  checksum: 8acefedc84be2693ecb688fe489f1ae7ff5b3be2bcb97ac2bc30500db5079f2325ba3844ff848c6aa453f7420fd29fd65f73e83df15fb44b15d49d78ea3abdda
   languageName: node
   linkType: hard
 
-"@docusaurus/types@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/types@npm:3.5.2-canary-6125"
+"@docusaurus/types@npm:3.6.0, @docusaurus/types@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/types@npm:3.6.0"
   dependencies:
     "@mdx-js/mdx": "npm:^3.0.0"
     "@types/history": "npm:^4.7.11"
@@ -3698,13 +3698,13 @@ __metadata:
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: f130b11954290c80773566d3e7d9059f8d98b79f803f9977b0190f7e9cb615560e4c7c4a21fd8117d121180493984911de77cf34295cdd390751b53837efb8fe
+  checksum: 88de48fce4963326aeb37a9668e60dd8da682c8e832dab04be1677c24b7720e919e266f8e820856b7fb48e09a6eb5d99dfcad9a3488e5a74384a55ae262ae75b
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-common@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/utils-common@npm:3.5.2-canary-6125"
+"@docusaurus/utils-common@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/utils-common@npm:3.6.0"
   dependencies:
     tslib: "npm:^2.6.0"
   peerDependencies:
@@ -3712,32 +3712,32 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: 6ec7fc4199521f49e0e3028f49b1384d470315cd31c8577a019b10288ebdf9189bdc10729e7e7a90beb36a848e104c88c69bcc367b4e57720050f1912cbb8e40
+  checksum: 473056b9a6e3fd7592698ca26cf4b4a4f2e1cbdf672b66c6d1cbeffd390e41081b8b44ccf93bb12ec279461a7163f37870b4b0d51630215d7f1f89865b7595a3
   languageName: node
   linkType: hard
 
-"@docusaurus/utils-validation@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/utils-validation@npm:3.5.2-canary-6125"
+"@docusaurus/utils-validation@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/utils-validation@npm:3.6.0"
   dependencies:
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
     fs-extra: "npm:^11.2.0"
     joi: "npm:^17.9.2"
     js-yaml: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
     tslib: "npm:^2.6.0"
-  checksum: 8e56480f0a1a8e9d63e004676a33f5b532c84e20c31a96bd37b0b60a635a0c680dab8d5549088c132a7ea2005ca07c278656286647820504eacc61dcda93727a
+  checksum: a500f9169539545f8e36791bee0d329df588a034458e0e3c7a0d599eef279513870b7f7c5f2396c4fa6833663d8580dbdc9aa5fb64c89e362d9fbd830c51b8b8
   languageName: node
   linkType: hard
 
-"@docusaurus/utils@npm:3.5.2-canary-6125":
-  version: 3.5.2-canary-6125
-  resolution: "@docusaurus/utils@npm:3.5.2-canary-6125"
+"@docusaurus/utils@npm:3.6.0, @docusaurus/utils@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@docusaurus/utils@npm:3.6.0"
   dependencies:
-    "@docusaurus/logger": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils-common": "npm:3.5.2-canary-6125"
+    "@docusaurus/logger": "npm:3.6.0"
+    "@docusaurus/utils-common": "npm:3.6.0"
     "@svgr/webpack": "npm:^8.1.0"
     escape-string-regexp: "npm:^4.0.0"
     file-loader: "npm:^6.2.0"
@@ -3761,7 +3761,7 @@ __metadata:
   peerDependenciesMeta:
     "@docusaurus/types":
       optional: true
-  checksum: e86b2e6cf81546b9b4ebcc32220752afac3c8ba534b3f0023ea07cc41cd2a00969ddc731fb608f924c7111344f4764b29afd840a3dfdc323fc71676c0630441a
+  checksum: 621c042bb38e2c911f168377ac276f79e2d2336f69086a2e72492af7dd72c30e5e25de2e38b545b14c5ce0c2ecd7596d98e8f640358dc7eba5b4819f3b824a31
   languageName: node
   linkType: hard
 
@@ -7982,8 +7982,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docusaurus-plugin-redoc@workspace:packages/docusaurus-plugin-redoc"
   dependencies:
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/types": "npm:^3.6.0"
+    "@docusaurus/utils": "npm:^3.6.0"
     "@redocly/openapi-core": "npm:1.16.0"
     core-js: "npm:^3.36.0"
     mobx: "npm:^6.12.4"
@@ -8002,10 +8002,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "docusaurus-theme-redoc@workspace:packages/docusaurus-theme-redoc"
   dependencies:
-    "@docusaurus/module-type-aliases": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-classic": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/types": "npm:3.5.2-canary-6125"
+    "@docusaurus/module-type-aliases": "npm:^3.6.0"
+    "@docusaurus/theme-classic": "npm:^3.6.0"
+    "@docusaurus/theme-common": "npm:^3.6.0"
+    "@docusaurus/types": "npm:^3.6.0"
     "@redocly/openapi-core": "npm:1.16.0"
     "@types/lodash": "npm:^4.14.200"
     "@types/postcss-prefix-selector": "npm:^1"
@@ -14950,11 +14950,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus-website@workspace:website"
   dependencies:
-    "@docusaurus/core": "npm:3.5.2-canary-6125"
-    "@docusaurus/faster": "npm:3.5.2-canary-6125"
-    "@docusaurus/preset-classic": "npm:3.5.2-canary-6125"
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/core": "npm:3.6.0"
+    "@docusaurus/faster": "npm:3.6.0"
+    "@docusaurus/preset-classic": "npm:3.6.0"
+    "@docusaurus/theme-common": "npm:3.6.0"
+    "@docusaurus/utils": "npm:3.6.0"
     "@percy/cli": "npm:^1.28.8"
     "@types/react": "npm:^18.3.3"
     clsx: "npm:^1.2.1"
@@ -14968,8 +14968,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "redocusaurus@workspace:packages/redocusaurus"
   dependencies:
-    "@docusaurus/theme-common": "npm:3.5.2-canary-6125"
-    "@docusaurus/utils": "npm:3.5.2-canary-6125"
+    "@docusaurus/theme-common": "npm:^3.6.0"
+    "@docusaurus/utils": "npm:^3.6.0"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     docusaurus-plugin-redoc: "npm:2.1.1"


### PR DESCRIPTION
- Upgrade website to Docusaurus v3.6
- Make this plugin compatible with [Docusaurus Faster](https://github.com/facebook/docusaurus/issues/10556)
- Keep retro-compatibility with lower versions


## Benchmark

Cold builds - 3.3x faster:

```bash
hyperfine --prepare 'yarn workspace redocusaurus-website clear' --runs 3 'DOCUSAURUS_FASTER=false yarn build:website' 'DOCUSAURUS_FASTER=true yarn build:website'


Benchmark 1: DOCUSAURUS_FASTER=false yarn build:website
  Time (mean ± σ):     15.677 s ±  1.331 s    [User: 26.425 s, System: 5.220 s]
  Range (min … max):   14.732 s … 17.199 s    3 runs

Benchmark 2: DOCUSAURUS_FASTER=true yarn build:website
  Time (mean ± σ):      4.714 s ±  0.558 s    [User: 7.375 s, System: 1.040 s]
  Range (min … max):    4.185 s …  5.297 s    3 runs

Summary
  DOCUSAURUS_FASTER=true yarn build:website ran
    3.33 ± 0.48 times faster than DOCUSAURUS_FASTER=false yarn build:website
```

Warn builds - almost the same:

```bash
DOCUSAURUS_FASTER=false yarn build:website
hyperfine --runs 3 'DOCUSAURUS_FASTER=false yarn build:website' 'DOCUSAURUS_FASTER=true yarn build:website'

Benchmark 1: DOCUSAURUS_FASTER=false yarn build:website
  Time (mean ± σ):      4.637 s ±  0.308 s    [User: 5.878 s, System: 0.614 s]
  Range (min … max):    4.282 s …  4.842 s    3 runs

Benchmark 2: DOCUSAURUS_FASTER=true yarn build:website
  Time (mean ± σ):      4.230 s ±  0.139 s    [User: 6.986 s, System: 1.055 s]
  Range (min … max):    4.075 s …  4.346 s    3 runs

Summary
  DOCUSAURUS_FASTER=true yarn build:website ran
    1.10 ± 0.08 times faster than DOCUSAURUS_FASTER=false yarn build:website
```


## Tests

Note: I'd recommend testing in particular Prism code blocks because I had weird SSG errors that I fixed with https://github.com/facebook/docusaurus/pull/10618

