### PR TITLE
feat: adjusts dark mode contrast for homepage

### DIFF
--- a/packages/docusaurus-theme-redoc/src/custom.css
+++ b/packages/docusaurus-theme-redoc/src/custom.css
@@ -1,3 +1,23 @@
+:root {
+  --ifm-color-primary: #552e85;
+  --ifm-color-primary-dark: #4c2978;
+  --ifm-color-primary-darker: #482771;
+  --ifm-color-primary-darkest: #3b205d;
+  --ifm-color-primary-light: #5d3392;
+  --ifm-color-primary-lighter: #623599;
+  --ifm-color-primary-lightest: #6e3cad;
+}
+
+[data-theme='dark'] {
+  --ifm-color-primary: #ededed;
+  --ifm-color-primary-dark: #d5d5d5;
+  --ifm-color-primary-darker: #c9c9c9;
+  --ifm-color-primary-darkest: #a6a6a6;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgb(72, 77, 91);
   display: block;

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
@@ -1,3 +1,23 @@
+:root {
+  --ifm-color-primary: #552e85;
+  --ifm-color-primary-dark: #4c2978;
+  --ifm-color-primary-darker: #482771;
+  --ifm-color-primary-darkest: #3b205d;
+  --ifm-color-primary-light: #5d3392;
+  --ifm-color-primary-lighter: #623599;
+  --ifm-color-primary-lightest: #6e3cad;
+}
+
+[data-theme='dark'] {
+  --ifm-color-primary: #ededed;
+  --ifm-color-primary-dark: #d5d5d5;
+  --ifm-color-primary-darker: #c9c9c9;
+  --ifm-color-primary-darkest: #a6a6a6;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
+}
+
 .redocusaurus-styles {
   display: none;
 }
@@ -134,10 +154,7 @@ html[data-theme='dark']
   background-color: var(--ifm-color-gray-800);
 }
 
-html[data-theme='dark']
-  .redocusaurus
-  div[id^='tag']
-  button + div {
+html[data-theme='dark'] .redocusaurus div[id^='tag'] button + div {
   background-color: var(--ifm-color-emphasis-0);
 }
 
@@ -150,18 +167,12 @@ html[data-theme='dark']
  * Code Samples
  * @see https://github.com/rohit-gohri/redocusaurus/issues/217
  */
-html:not([data-theme='dark'])
-  .redocusaurus
-  [role='tabpanel']
-  pre {
+html:not([data-theme='dark']) .redocusaurus [role='tabpanel'] pre {
   background-color: transparent;
 }
 
 /** https://github.com/rohit-gohri/redocusaurus/issues/45 */
-html:not([data-theme='dark'])
-  .redocusaurus
-  [role='tabpanel']
-  code {
+html:not([data-theme='dark']) .redocusaurus [role='tabpanel'] code {
   color: var(--ifm-color-emphasis-0);
 }
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -134,7 +134,7 @@ const config: Config = {
       ],
     },
     footer: {
-      style: 'dark',
+      style: 'light',
       links: [
         {
           title: 'NPM Modules',

--- a/website/src/custom.css
+++ b/website/src/custom.css
@@ -1,3 +1,23 @@
+:root {
+  --ifm-color-primary: #552e85;
+  --ifm-color-primary-dark: #4c2978;
+  --ifm-color-primary-darker: #482771;
+  --ifm-color-primary-darkest: #3b205d;
+  --ifm-color-primary-light: #5d3392;
+  --ifm-color-primary-lighter: #623599;
+  --ifm-color-primary-lightest: #6e3cad;
+}
+
+[data-theme='dark'] {
+  --ifm-color-primary: #ededed;
+  --ifm-color-primary-dark: #d5d5d5;
+  --ifm-color-primary-darker: #c9c9c9;
+  --ifm-color-primary-darkest: #a6a6a6;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
+}
+
 .header-github-logo:before {
   content: '';
   width: 24px;
@@ -13,9 +33,9 @@ html[data-theme='dark'] .header-github-logo:before {
 }
 
 .footer-link {
-  color: white;
+  color: var(--ifm-color-primary-lightest);
   font-weight: bold;
 }
 .footer-link:hover {
-  color: white;
+  color: var(--ifm-color-primary-lightest);
 }

--- a/website/src/pages/examples/styles.module.css
+++ b/website/src/pages/examples/styles.module.css
@@ -1,5 +1,25 @@
 /* stylelint-disable docusaurus/copyright-header */
 
+:root {
+  --ifm-color-primary: #552e85;
+  --ifm-color-primary-dark: #4c2978;
+  --ifm-color-primary-darker: #482771;
+  --ifm-color-primary-darkest: #3b205d;
+  --ifm-color-primary-light: #5d3392;
+  --ifm-color-primary-lighter: #623599;
+  --ifm-color-primary-lightest: #6e3cad;
+}
+
+[data-theme='dark'] {
+  --ifm-color-primary: #ededed;
+  --ifm-color-primary-dark: #d5d5d5;
+  --ifm-color-primary-darker: #c9c9c9;
+  --ifm-color-primary-darkest: #a6a6a6;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
+}
+
 /**
  * CSS files with the .module.css suffix will be treated as CSS modules
  * and scoped locally.

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -1,5 +1,25 @@
 /* stylelint-disable docusaurus/copyright-header */
 
+:root {
+  --ifm-color-primary: #29369e;
+  --ifm-color-primary-dark: #25318e;
+  --ifm-color-primary-darker: #232e86;
+  --ifm-color-primary-darkest: #1d266f;
+  --ifm-color-primary-light: #2d3bae;
+  --ifm-color-primary-lighter: #2f3eb6;
+  --ifm-color-primary-lightest: #3748cb;
+}
+
+[data-theme='dark'] {
+  --ifm-color-primary: #ededed;
+  --ifm-color-primary-dark: #d5d5d5;
+  --ifm-color-primary-darker: #c9c9c9;
+  --ifm-color-primary-darkest: #a6a6a6;
+  --ifm-color-primary-light: #ffffff;
+  --ifm-color-primary-lighter: #ffffff;
+  --ifm-color-primary-lightest: #ffffff;
+}
+
 /**
  * CSS files with the .module.css suffix will be treated as CSS modules
  * and scoped locally.
@@ -41,9 +61,9 @@
 }
 
 .link {
-  color: white;
+  color: #359962;
   font-weight: bold;
 }
 .link:hover {
-  color: white;
+  color: #359962;
 }


### PR DESCRIPTION
This PR fixes the contrast issue on the main homepage of the website.

Light Mode (Before):

<img width="1728" alt="Screenshot 2025-02-23 at 21 23 06" src="https://github.com/user-attachments/assets/1913aba8-2b9b-415e-a349-3b231f084f49" />

Dark Mode (Before):

<img width="1728" alt="Screenshot 2025-02-23 at 21 23 35" src="https://github.com/user-attachments/assets/8c281550-b505-4a94-8e7a-9f5ec1f3c9ea" />


Light Mode (Before):

<img width="1728" alt="Screenshot 2025-02-23 at 21 24 05" src="https://github.com/user-attachments/assets/be1b83a8-e13b-4bfa-86f9-e3c2280142a0" />

Dark Mode (After):

<img width="1728" alt="Screenshot 2025-02-23 at 21 24 34" src="https://github.com/user-attachments/assets/cb4e833b-3f5d-456e-89fc-c37a9d32e3b0" />
