### PR TITLE
Fix: authorization dropdown background contrast issue in dark mode

### DIFF
--- a/.changeset/quiet-mayflies-brush.md
+++ b/.changeset/quiet-mayflies-brush.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-theme-redoc': patch
+---
+
+fix authorization dropdown contrast issue in dark mode

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
@@ -213,6 +213,10 @@ html:not([data-theme='dark'])
   background-color: var(--ifm-background-surface-color);
 }
 
+[data-theme='dark'] .redocusaurus .api-content div h5 + svg polygon {
+  filter: invert(1);
+}
+
 [data-theme='dark'] .redocusaurus .api-content div:has(> span > span > i + code) {
   background: var(--ifm-color-emphasis-0);
 }

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/styles.css
@@ -213,6 +213,6 @@ html:not([data-theme='dark'])
   background-color: var(--ifm-background-surface-color);
 }
 
-[data-theme='dark'] .redocusaurus .api-content div h5 + svg polygon {
-  filter: invert(1);
+[data-theme='dark'] .redocusaurus .api-content div:has(> span > span > i + code) {
+  background: var(--ifm-color-emphasis-0);
 }


### PR DESCRIPTION
Fixes: https://github.com/rohit-gohri/redocusaurus/issues/231

Current: 
![image](https://github.com/user-attachments/assets/13325245-6f79-4cf0-864f-28c69257ac60)

Post fix: 
Default: 
![image](https://github.com/user-attachments/assets/67c3daa0-b872-428a-9721-3d444604c8c5)

Dropdown open: 
![image](https://github.com/user-attachments/assets/000f7b85-610c-4a2c-8fd6-4d6af4f38b0b)


Light Mode: 
![image](https://github.com/user-attachments/assets/0ab88552-8d87-4043-8dd2-7ba6d3be896d)
![image](https://github.com/user-attachments/assets/8661dc75-c570-44ad-86a8-290b40daf8c0)

