### PR TITLE
Register anchors in ServerRedoc component

### DIFF
--- a/.changeset/long-tables-clap.md
+++ b/.changeset/long-tables-clap.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-theme-redoc': minor
+---
+
+Register Redoc anchors with Docusaurus

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerRedoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerRedoc.tsx
@@ -4,7 +4,7 @@ import '../../global';
 import { IMenuItem, Redoc as RedocComponent, RedocRawOptions } from 'redoc';
 import type { SpecProps } from '../../types/common';
 import { useSpec } from '../../utils/useSpec';
-import useBrokenLinks from '@docusaurus/useBrokenLinks';
+import useBrokenLinks, { BrokenLinks } from '@docusaurus/useBrokenLinks';
 import { ServerStyles } from './Styles';
 import './styles.css';
 
@@ -26,7 +26,8 @@ function ServerRedoc(
     optionsOverrides,
   );
 
-  collectMenuItemAnchors(store.menu.items);
+  const collector = useBrokenLinks();
+  collectMenuItemAnchors(collector, store.menu.items);
 
   return (
     <>
@@ -48,21 +49,21 @@ function ServerRedoc(
   );
 }
 
-function collectMenuItemAnchors(menuItems: IMenuItem[], parentAnchor = "") {
+function collectMenuItemAnchors(collector: BrokenLinks, menuItems: IMenuItem[], parentAnchor = "") {
   menuItems.forEach((menuItem) => {
     // Register anchor for menu item
-    useBrokenLinks().collectAnchor(menuItem.id);
+    collector.collectAnchor(menuItem.id);
 
     // If this is a child menu item, register a shortened anchor as well
     // This may not be necessary in all cases, but definitely needed for
     // menuItems of the form `tag/<Tag ID>/operation/<Operation ID>`.
     if (parentAnchor != "") {
       const childAnchor = menuItem.id.replace(`${parentAnchor}/`, "")
-      useBrokenLinks().collectAnchor(childAnchor);
+      collector.collectAnchor(childAnchor);
     }
 
     if (menuItem.items.length > 0) {
-      collectMenuItemAnchors(menuItem.items, menuItem.id)
+      collectMenuItemAnchors(collector, menuItem.items, menuItem.id)
     }
   })
 }

--- a/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerRedoc.tsx
+++ b/packages/docusaurus-theme-redoc/src/theme/Redoc/ServerRedoc.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
 import '../../global';
-import { Redoc as RedocComponent, RedocRawOptions } from 'redoc';
+import { IMenuItem, Redoc as RedocComponent, RedocRawOptions } from 'redoc';
 import type { SpecProps } from '../../types/common';
 import { useSpec } from '../../utils/useSpec';
+import useBrokenLinks from '@docusaurus/useBrokenLinks';
 import { ServerStyles } from './Styles';
 import './styles.css';
 
@@ -25,6 +26,8 @@ function ServerRedoc(
     optionsOverrides,
   );
 
+  collectMenuItemAnchors(store.menu.items);
+
   return (
     <>
       <ServerStyles
@@ -43,6 +46,25 @@ function ServerRedoc(
       </div>
     </>
   );
+}
+
+function collectMenuItemAnchors(menuItems: IMenuItem[], parentAnchor = "") {
+  menuItems.forEach((menuItem) => {
+    // Register anchor for menu item
+    useBrokenLinks().collectAnchor(menuItem.id);
+
+    // If this is a child menu item, register a shortened anchor as well
+    // This may not be necessary in all cases, but definitely needed for
+    // menuItems of the form `tag/<Tag ID>/operation/<Operation ID>`.
+    if (parentAnchor != "") {
+      const childAnchor = menuItem.id.replace(`${parentAnchor}/`, "")
+      useBrokenLinks().collectAnchor(childAnchor);
+    }
+
+    if (menuItem.items.length > 0) {
+      collectMenuItemAnchors(menuItem.items, menuItem.id)
+    }
+  })
 }
 
 export default ServerRedoc;


### PR DESCRIPTION
This uses the `useBrokenLinks` Docusaurus hook to register Redoc-generated anchors so that Redocusaurus users can configure their sites to fail to build if there are broken anchors.

The ServerRedoc component is the only one that registers anchors because if a Redoc page is rendered on the client side it is too late to register anchors for the Docusaurus build.

Closes #321 