### PR TITLE
Add ProvidePlugin for Prism in Webpack config

### DIFF
--- a/.changeset/curvy-sloths-poke.md
+++ b/.changeset/curvy-sloths-poke.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-theme-redoc': patch
+---
+
+Fixes "ReferenceError: Prism is not defined" when using @docusaurus/faster with additionalLanguages

--- a/packages/docusaurus-theme-redoc/src/index.ts
+++ b/packages/docusaurus-theme-redoc/src/index.ts
@@ -17,6 +17,9 @@ export default function redocTheme(
       const bundler = currentBundler.instance ?? require("webpack")
       return {
         plugins: [
+          new currentBundler.instance.ProvidePlugin({
+            Prism: ['prismjs'],
+          }),
           new bundler.NormalModuleReplacementPlugin(
             /^tty$/,
             require.resolve('./tty'),

--- a/packages/docusaurus-theme-redoc/src/index.ts
+++ b/packages/docusaurus-theme-redoc/src/index.ts
@@ -17,7 +17,7 @@ export default function redocTheme(
       const bundler = currentBundler.instance ?? require("webpack")
       return {
         plugins: [
-          new currentBundler.instance.ProvidePlugin({
+          new bundler.instance.ProvidePlugin({
             Prism: ['prismjs'],
           }),
           new bundler.NormalModuleReplacementPlugin(


### PR DESCRIPTION
Fixes "ReferenceError: Prism is not defined" when using @docusaurus/faster with additionalLanguages